### PR TITLE
Include full reply-chain context by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Open-source API and landing page that turns public **X posts into Markdown** you
 ## Features
 
 - **Markdown** and **Obsidian** (`?format=obsidian`) output with YAML frontmatter
-- **Threads** (`?thread=full` or `?thread=2-100`)
+- **Threads** (default `full`): conversation ancestors and author continuations; use `?thread=off` for a single post only
 - **Author metadata** (`?userinfo=author` or `all`)
 - **X Articles** when the primary provider returns article blocks
 - **Provider chain**: FxTwitter (primary), X syndication CDN (fallback), optional [Firecrawl](https://firecrawl.dev) scrape
@@ -62,7 +62,7 @@ Same query params as below.
 | --- | --- | --- |
 | `url` | — | Encoded X status URL (required on `/api/convert`) |
 | `format` | `markdown` | `markdown`, `obsidian` |
-| `thread` | `off` | `off`, `full`, `2-100` |
+| `thread` | `full` | `off`, `full`, `conversation`, `2-100` |
 | `userinfo` | `off` | `off`, `author`, `all` |
 | `nocache` | — | Bypass cache when set |
 

--- a/lib/converter.ts
+++ b/lib/converter.ts
@@ -104,10 +104,12 @@ function parseFormat(raw: string | null | undefined): OutputFormat {
   throw new ConvertError(400, '`format` must be `markdown` or `obsidian`.', 'invalid_format')
 }
 
-function parseThread(raw: string | null | undefined): { mode: 'off' | 'full'; limit: number } {
-  if (!raw || raw === 'off') return { mode: 'off', limit: 1 }
+const DEFAULT_THREAD = 'full'
 
-  if (raw === 'full') return { mode: 'full', limit: 100 }
+function parseThread(raw: string | null | undefined): { mode: 'off' | 'full'; limit: number } {
+  if (raw === 'off') return { mode: 'off', limit: 1 }
+
+  if (!raw || raw === 'full' || raw === 'conversation') return { mode: 'full', limit: 100 }
 
   const n = Number.parseInt(raw, 10)
   if (Number.isFinite(n) && n >= 2 && n <= 100) {
@@ -116,7 +118,7 @@ function parseThread(raw: string | null | undefined): { mode: 'off' | 'full'; li
 
   throw new ConvertError(
     400,
-    '`thread` must be `off`, `full`, or a number from 2 to 100.',
+    '`thread` must be `off`, `full`, `conversation`, or a number from 2 to 100.',
     'invalid_thread',
   )
 }
@@ -184,10 +186,10 @@ export async function convertTweet(input: ConvertInput): Promise<ConvertSuccess>
   const { canonicalUrl, handle, id } = resolveTarget(input)
 
   const cacheKey = buildCacheKey({
-    v: 1,
+    v: 2,
     id,
     format,
-    thread: input.thread ?? 'off',
+    thread: input.thread ?? DEFAULT_THREAD,
     userinfo: input.userinfo ?? 'off',
   })
 

--- a/lib/converter.ts
+++ b/lib/converter.ts
@@ -106,6 +106,12 @@ function parseFormat(raw: string | null | undefined): OutputFormat {
 
 const DEFAULT_THREAD = 'full'
 
+function canonicalThreadCacheValue(raw: string | null | undefined): string {
+  if (raw === 'off') return 'off'
+  if (!raw || raw === 'full' || raw === 'conversation') return DEFAULT_THREAD
+  return raw
+}
+
 function parseThread(raw: string | null | undefined): { mode: 'off' | 'full'; limit: number } {
   if (raw === 'off') return { mode: 'off', limit: 1 }
 
@@ -189,7 +195,7 @@ export async function convertTweet(input: ConvertInput): Promise<ConvertSuccess>
     v: 2,
     id,
     format,
-    thread: input.thread ?? DEFAULT_THREAD,
+    thread: canonicalThreadCacheValue(input.thread),
     userinfo: input.userinfo ?? 'off',
   })
 

--- a/lib/fxtwitter.ts
+++ b/lib/fxtwitter.ts
@@ -171,20 +171,21 @@ export async function fetchFxConversationChain(
   id: string,
   limit = 100,
 ): Promise<FxTweet[]> {
-  const chain: FxTweet[] = []
+  const walked: FxTweet[] = []
   const seen = new Set<string>()
   let currentId: string | undefined = id
 
-  while (currentId && chain.length < limit) {
+  while (currentId && walked.length < 100) {
     if (seen.has(currentId)) break
     seen.add(currentId)
 
     const tweet = await fetchFxStatus(currentId)
-    chain.unshift(tweet)
+    walked.push(tweet)
     currentId = getParentStatusId(tweet)
   }
 
-  return chain
+  walked.reverse()
+  return walked.slice(0, limit)
 }
 
 export async function fetchFxThread(id: string): Promise<FxTweet[]> {

--- a/lib/fxtwitter.ts
+++ b/lib/fxtwitter.ts
@@ -179,9 +179,14 @@ export async function fetchFxConversationChain(
     if (seen.has(currentId)) break
     seen.add(currentId)
 
-    const tweet = await fetchFxStatus(currentId)
-    walked.push(tweet)
-    currentId = getParentStatusId(tweet)
+    try {
+      const tweet = await fetchFxStatus(currentId)
+      walked.push(tweet)
+      currentId = getParentStatusId(tweet)
+    } catch (error) {
+      if (error instanceof ConvertError && error.code === 'private_tweet') throw error
+      break
+    }
   }
 
   walked.reverse()

--- a/lib/fxtwitter.ts
+++ b/lib/fxtwitter.ts
@@ -55,6 +55,17 @@ export interface FxArticle {
   }
 }
 
+/** FxTwitter may return a single parent object or legacy string[] handles. */
+export type FxReplyingTo =
+  | string[]
+  | {
+      screen_name?: string
+      status?: string
+      url?: string
+      profile_url?: string
+    }
+  | null
+
 export interface FxTweet {
   url?: string
   id?: string
@@ -71,7 +82,7 @@ export interface FxTweet {
   quotes?: number
   lang?: string
   source?: string
-  replying_to?: string[] | null
+  replying_to?: FxReplyingTo
   replying_to_status?: string[] | null
   possibly_sensitive?: boolean
   media?: FxMedia
@@ -142,6 +153,40 @@ export async function fetchFxStatus(id: string): Promise<FxTweet> {
   return tweet
 }
 
+export function getParentStatusId(tweet: FxTweet): string | undefined {
+  const replyingTo = tweet.replying_to
+  if (replyingTo && !Array.isArray(replyingTo)) {
+    const status = replyingTo.status
+    if (status) return String(status)
+  }
+
+  const fromStatus = tweet.replying_to_status?.[0]
+  if (fromStatus) return String(fromStatus)
+
+  return undefined
+}
+
+/** Walk parent replies from root through the given status id (inclusive). */
+export async function fetchFxConversationChain(
+  id: string,
+  limit = 100,
+): Promise<FxTweet[]> {
+  const chain: FxTweet[] = []
+  const seen = new Set<string>()
+  let currentId: string | undefined = id
+
+  while (currentId && chain.length < limit) {
+    if (seen.has(currentId)) break
+    seen.add(currentId)
+
+    const tweet = await fetchFxStatus(currentId)
+    chain.unshift(tweet)
+    currentId = getParentStatusId(tweet)
+  }
+
+  return chain
+}
+
 export async function fetchFxThread(id: string): Promise<FxTweet[]> {
   const data = await fxFetch(`2/thread/${id}`)
   if (data.thread?.length) {
@@ -149,3 +194,23 @@ export async function fetchFxThread(id: string): Promise<FxTweet[]> {
   }
   return [await fetchFxStatus(id)]
 }
+
+/**
+ * Full thread: FxTwitter thread endpoint (author threads + reply chains), with a
+ * parent-walk fallback when the endpoint returns only the requested status.
+ */
+export async function fetchFxFullThread(id: string, limit = 100): Promise<FxTweet[]> {
+  const fromThread = await fetchFxThread(id)
+  if (fromThread.length > 1) {
+    return fromThread.length > limit ? fromThread.slice(0, limit) : fromThread
+  }
+
+  const tweet = fromThread[0] ?? (await fetchFxStatus(id))
+  if (!getParentStatusId(tweet)) {
+    return [tweet]
+  }
+
+  const chain = await fetchFxConversationChain(id, limit)
+  return chain.length > 0 ? chain : [tweet]
+}
+

--- a/lib/tweet-fetch.ts
+++ b/lib/tweet-fetch.ts
@@ -1,6 +1,6 @@
 import { ConvertError } from './errors.js'
 import { fetchFirecrawlStatus } from './firecrawl.js'
-import { fetchFxStatus, fetchFxThread, type FxTweet } from './fxtwitter.js'
+import { fetchFxFullThread, fetchFxStatus, type FxTweet } from './fxtwitter.js'
 import { fetchSyndicationStatus } from './syndication.js'
 
 export type FetchSource = 'fxtwitter' | 'syndication' | 'firecrawl'
@@ -53,7 +53,7 @@ export async function fetchPosts(
   }
 
   try {
-    const tweets = await fetchFxThread(id)
+    const tweets = await fetchFxFullThread(id)
     return { tweets, source: 'fxtwitter' }
   } catch (error) {
     if (isHardNotFound(error)) throw error

--- a/scripts/read-x.ts
+++ b/scripts/read-x.ts
@@ -11,7 +11,7 @@ function usage(): never {
 
 Options:
   --format markdown|obsidian   Output format (default: markdown)
-  --thread off|full|N          Thread mode (default: off)
+  --thread off|full|conversation|N   Thread mode (default: full)
   --userinfo off|author|all    Author metadata (default: off)
   --json                       Emit JSON instead of Markdown
   --nocache                    Bypass converter cache

--- a/skills/read-x-links-local/SKILL.md
+++ b/skills/read-x-links-local/SKILL.md
@@ -21,10 +21,12 @@ Run from the **x-md** workspace root.
 bun run read-x -- "https://x.com/handle/status/1234567890"
 ```
 
+By default, reply chains are expanded from the root post through the URL you pass (`thread=full`). Use `--thread off` for a single post only.
+
 Or:
 
 ```bash
-bun scripts/read-x.ts "https://x.com/handle/status/1234567890" --thread full --userinfo author
+bun scripts/read-x.ts "https://x.com/handle/status/1234567890" --userinfo author
 ```
 
 Helper script (from repo root):

--- a/skills/read-x-links-vercel/SKILL.md
+++ b/skills/read-x-links-vercel/SKILL.md
@@ -28,6 +28,8 @@ curl -sS -G "https://x.pcstyle.dev/api/convert" \
   -H "Accept: text/markdown"
 ```
 
+By default, reply chains are expanded from the root post through the URL you pass (`thread=full`). Use `thread=off` for a single post only.
+
 Path rewrite:
 
 ```text

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ function setupConvertForm(root: HTMLElement) {
     e.preventDefault()
     const raw = input.value.trim()
     if (!raw) return
-    const target = `/api/convert?url=${encodeURIComponent(raw)}`
+    const target = `/api/convert?url=${encodeURIComponent(raw)}&thread=full`
     window.open(target, '_blank', 'noopener,noreferrer')
   })
 }
@@ -91,7 +91,7 @@ returns X Article blocks…</pre>
       <div class="container-page reveal">
         <div class="mx-auto max-w-xl">
           <h2 class="section-title">Convert a post</h2>
-          <p class="mt-2 text-muted">Paste any public X status URL. Opens Markdown in a new tab.</p>
+          <p class="mt-2 text-muted">Paste any public X status URL. Opens Markdown in a new tab (includes reply-chain context by default).</p>
           <form data-convert-form class="mt-6 flex flex-col gap-3 sm:flex-row">
             <input
               data-convert-input
@@ -161,7 +161,7 @@ Accept: text/markdown
             <thead><tr><th>Param</th><th>Default</th><th>Values</th></tr></thead>
             <tbody>
               <tr><td><code>format</code></td><td>markdown</td><td><code>markdown</code>, <code>obsidian</code></td></tr>
-              <tr><td><code>thread</code></td><td>off</td><td><code>off</code>, <code>full</code>, <code>2-100</code></td></tr>
+              <tr><td><code>thread</code></td><td>full</td><td><code>off</code>, <code>full</code>, <code>conversation</code>, <code>2-100</code></td></tr>
               <tr><td><code>userinfo</code></td><td>off</td><td><code>off</code>, <code>author</code>, <code>all</code></td></tr>
               <tr><td><code>url</code></td><td>-</td><td>Encoded X status URL (required on <code>/api/convert</code>)</td></tr>
             </tbody>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Converting a reply URL (e.g. `https://x.com/nicolaygerold/status/2061338731286540432`) returned only that single post, missing the parent conversation shown on X.

## Solution

- Default `thread` mode is now **`full`** instead of `off`, so the API returns the conversation from the root post through the requested status (when FxTwitter provides it).
- Added `fetchFxFullThread` with a **parent-walk fallback** via `replying_to.status` when the thread endpoint returns a single tweet that is still a reply.
- `thread=conversation` is accepted as an alias for `full`.
- Landing page convert form and docs updated; use `thread=off` for single-post output only.

## Example

For the Nicolay/Benjamin thread, default output is now 4 numbered posts (root → target) instead of 1.

## Breaking change

API consumers that relied on implicit `thread=off` will now receive multi-post output unless they pass `thread=off`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87aed8fb-3426-4d8d-be21-fda8aa3dbf5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87aed8fb-3426-4d8d-be21-fda8aa3dbf5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include reply-chain context by default when converting X posts. A status URL now returns the full conversation from the root post through the target (or the longest available chain if some parents are unavailable) unless `thread=off` is set.

- **New Features**
  - Default `thread` is now `full` (alias `conversation`); landing page form, docs, CLI, and skills updated; canonicalized cache keys for default/`full`/`conversation`; bumped converter cache key to v2.
  - Added `fetchFxFullThread` with a parent-walk fallback using `replying_to.status`; returns root-first output, applies `thread=N` after walking, and falls back to a partial chain when a parent post is missing.

- **Migration**
  - If you need single-post output, pass `thread=off`.

<sup>Written for commit bfefaa2179455e6b20f018f19861bca97357f557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pc-style/x-md/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

