### PR TITLE
Redesign landing page with Linear theme and hosted-service docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ src/assets/
 .env.local
 .cursor/
 .vercel
+
+.kombai/
+
+x.md.ignore*

--- a/README.md
+++ b/README.md
@@ -28,16 +28,21 @@ Open [http://localhost:5173](http://localhost:5173), paste a public status URL, 
 
 ## Agent skills
 
-Cursor agents can read X links via bundled skills:
+Cursor agents can read X links via bundled skills. Install with the [skills CLI](https://skills.sh/):
 
-| Skill | Location | How |
-| --- | --- | --- |
-| Local CLI | `skills/read-x-links-local/` | `bun run read-x -- "<url>"` |
-| Hosted API | `skills/read-x-links-vercel/` | `https://x.pcstyle.dev/api/convert?url=...` |
+```bash
+npx skills add pc-style/x-md --list
+
+npx skills add pc-style/x-md -g -y \
+  --skill read-x-links-vercel --skill read-x-links-local
+```
+
+| Skill | Use when |
+| --- | --- |
+| `read-x-links-vercel` | Hosted API at `x.pcstyle.dev` — no local repo |
+| `read-x-links-local` | Full threads, Firecrawl fallback, working in this repo |
 
 Live site: [https://x.pcstyle.dev](https://x.pcstyle.dev)
-
-Personal copies (with helper scripts): `~/.agents/skills/read-x-links-local/` and `read-x-links-vercel/`.
 
 ## API
 

--- a/api/convert.ts
+++ b/api/convert.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { ConvertError, convertTweet, markdownResponse } from '../lib/converter.js'
+import { ConvertError, acceptPrefersHtml, convertTweet, markdownResponse } from '../lib/converter.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET' && req.method !== 'HEAD') {
@@ -9,6 +9,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const accept = String(req.headers.accept ?? '')
   const asJson = accept.includes('application/json')
+  const asHtml = acceptPrefersHtml(accept)
 
   try {
     const result = await convertTweet({
@@ -21,7 +22,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       nocache: typeof req.query.nocache === 'string' ? req.query.nocache : undefined,
     })
 
-    const { status, headers, body } = markdownResponse(result, asJson)
+    const { status, headers, body } = markdownResponse(result, asJson, asHtml)
     for (const [key, value] of Object.entries(headers)) {
       res.setHeader(key, value)
     }

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <meta name="keywords" content="X, Twitter, Markdown, converter, API, open source, Vercel, Obsidian, agent" />
     <meta name="author" content="x.md contributors" />
     <meta name="robots" content="index, follow, max-image-preview:large" />
-    <meta name="theme-color" content="#0c0f14" />
-    <meta name="color-scheme" content="dark light" />
+    <meta name="theme-color" content="#08090a" />
+    <meta name="color-scheme" content="dark" />
     <title>x.md — open-source X to Markdown API</title>
     <link rel="canonical" href="https://x.pcstyle.dev/" />
     <link rel="alternate" hreflang="en" href="https://x.pcstyle.dev/" />

--- a/lib/converter.ts
+++ b/lib/converter.ts
@@ -206,7 +206,36 @@ export async function convertTweet(input: ConvertInput): Promise<ConvertSuccess>
   return { ...value, cache: status }
 }
 
-export function markdownResponse(result: ConvertSuccess, asJson = false): {
+export function acceptPrefersHtml(accept: string): boolean {
+  if (accept.includes('application/json') || accept.includes('text/markdown')) return false
+  return accept.includes('text/html')
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function htmlMarkdownPage(markdown: string, canonicalUrl: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${escapeHtml(canonicalUrl)} · x.md</title>
+  <style>
+    body { margin: 0; background: #08090a; color: #d0d6e0; font-family: "IBM Plex Mono", ui-monospace, monospace; }
+    pre { margin: 0; padding: 1.5rem; white-space: pre-wrap; word-break: break-word; line-height: 1.65; font-size: 13px; }
+  </style>
+</head>
+<body><pre>${escapeHtml(markdown)}</pre></body>
+</html>`
+}
+
+export function markdownResponse(result: ConvertSuccess, asJson = false, asHtml = false): {
   status: number
   headers: Record<string, string>
   body: string
@@ -236,6 +265,14 @@ export function markdownResponse(result: ConvertSuccess, asJson = false): {
         source: result.source,
         cache: result.cache,
       }),
+    }
+  }
+
+  if (asHtml) {
+    return {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8', ...sharedHeaders },
+      body: htmlMarkdownPage(result.body, result.canonicalUrl),
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,19 +198,24 @@ Accept: text/markdown
         <p class="eyebrow eyebrow-muted mb-3">Automation</p>
         <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">AI agents</h3>
         <p class="mt-3 max-w-[640px] text-[16px] leading-relaxed text-[#8a8f98]">
-          Easiest path: swap the host and fetch Markdown. For Cursor and other agents, install the bundled skills into <code class="code-chip">~/.agents/skills/</code> (from a clone of this repo):
+          Easiest path: swap the host and fetch Markdown. For Cursor and other agents, install the bundled skills with the <a href="https://skills.sh/" class="text-[#7170ff] hover:text-[#828fff]" target="_blank" rel="noreferrer">skills</a> CLI:
         </p>
-        <pre class="code-block mt-6">git clone https://github.com/pc-style/x-md.git
-cd x-md
-mkdir -p ~/.agents/skills
-cp -r skills/read-x-links-vercel ~/.agents/skills/
-cp -r skills/read-x-links-local ~/.agents/skills/
-chmod +x ~/.agents/skills/read-x-links-*/scripts/read-x.sh</pre>
+        <pre class="code-block mt-6"># list skills in this repo
+npx skills add pc-style/x-md --list
+
+# global install (recommended — works across projects)
+npx skills add pc-style/x-md -g -y \\
+  --skill read-x-links-vercel --skill read-x-links-local
+
+# or project-only, from an x-md checkout
+npx skills add pc-style/x-md -y \\
+  --skill read-x-links-vercel --skill read-x-links-local</pre>
         <div class="mt-8 grid gap-4 lg:grid-cols-2">
           <div class="compare-tile">
             <h4>read-x-links-vercel</h4>
             <p class="mt-2 text-[14px] leading-relaxed text-[#8a8f98]">Hosted API only — no local repo or Bun required. Uses FxTwitter + syndication on x.pcstyle.dev (no Firecrawl).</p>
-            <pre class="code-block mt-4 text-[12px]">~/.agents/skills/read-x-links-vercel/scripts/read-x.sh \\
+            <pre class="code-block mt-4 text-[12px]"># after npx skills add …
+~/.agents/skills/read-x-links-vercel/scripts/read-x.sh \\
   "${EXAMPLE_X_URL}"
 
 # or from this repo without installing:

--- a/src/main.ts
+++ b/src/main.ts
@@ -198,13 +198,46 @@ Accept: text/markdown
         <p class="eyebrow eyebrow-muted mb-3">Automation</p>
         <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">AI agents</h3>
         <p class="mt-3 max-w-[640px] text-[16px] leading-relaxed text-[#8a8f98]">
-          Easiest path: swap the host and fetch Markdown. For tools that need a single URL param, use <code class="code-chip">/api/convert?url=…</code>. Repo skills live under <code class="code-chip">skills/read-x-links-*</code>.
+          Easiest path: swap the host and fetch Markdown. For Cursor and other agents, install the bundled skills into <code class="code-chip">~/.agents/skills/</code> (from a clone of this repo):
         </p>
-        <pre class="code-block mt-6"># path-style (preferred)
+        <pre class="code-block mt-6">git clone https://github.com/pc-style/x-md.git
+cd x-md
+mkdir -p ~/.agents/skills
+cp -r skills/read-x-links-vercel ~/.agents/skills/
+cp -r skills/read-x-links-local ~/.agents/skills/
+chmod +x ~/.agents/skills/read-x-links-*/scripts/read-x.sh</pre>
+        <div class="mt-8 grid gap-4 lg:grid-cols-2">
+          <div class="compare-tile">
+            <h4>read-x-links-vercel</h4>
+            <p class="mt-2 text-[14px] leading-relaxed text-[#8a8f98]">Hosted API only — no local repo or Bun required. Uses FxTwitter + syndication on x.pcstyle.dev (no Firecrawl).</p>
+            <pre class="code-block mt-4 text-[12px]">~/.agents/skills/read-x-links-vercel/scripts/read-x.sh \\
+  "${EXAMPLE_X_URL}"
+
+# or from this repo without installing:
+./skills/read-x-links-vercel/scripts/read-x.sh \\
+  "${EXAMPLE_X_URL}"</pre>
+          </div>
+          <div class="compare-tile">
+            <h4>read-x-links-local</h4>
+            <p class="mt-2 text-[14px] leading-relaxed text-[#8a8f98]">Full local CLI — threads, Obsidian output, optional Firecrawl when you set <code class="code-chip">FIRECRAWL_API_KEY</code>.</p>
+            <pre class="code-block mt-4 text-[12px]">cd x-md && bun install
+cp .env.local.example .env.local   # optional
+
+bun run read-x -- "${EXAMPLE_X_URL}" --thread full
+
+# or the installed skill script (needs X_MD_ROOT):
+~/.agents/skills/read-x-links-local/scripts/read-x.sh \\
+  "${EXAMPLE_X_URL}" --thread full</pre>
+          </div>
+        </div>
+        <p class="mt-6 text-[16px] leading-relaxed text-[#8a8f98]">
+          Raw HTTP without skills — path-style first, query-style when you need an encoded URL:
+        </p>
+        <pre class="code-block mt-4"># path-style (preferred)
 curl -sS -H "Accept: text/markdown" \\
   "${EXAMPLE_HOSTED_URL}?thread=full"
 
-# query-style (agents / encoded URLs)
+# query-style (tools that only accept ?url=)
 curl -sS -G "https://x.pcstyle.dev/api/convert" \\
   --data-urlencode "url=${EXAMPLE_X_URL}" \\
   -H "Accept: text/markdown"</pre>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,26 @@ import './style.css'
 
 const app = document.querySelector<HTMLDivElement>('#app')!
 
-const EXAMPLE_URL = 'https://x.com/trq212/status/2052809885763747935'
+const EXAMPLE_HANDLE = 'trq212'
+const EXAMPLE_ID = '2052809885763747935'
+const EXAMPLE_X_URL = `https://x.com/${EXAMPLE_HANDLE}/status/${EXAMPLE_ID}`
+const EXAMPLE_HOSTED_URL = `https://x.pcstyle.dev/${EXAMPLE_HANDLE}/status/${EXAMPLE_ID}`
+const EXAMPLE_PATH = `/${EXAMPLE_HANDLE}/status/${EXAMPLE_ID}`
+
+function statusPathFromUrl(raw: string): string | null {
+  try {
+    const parsed = new URL(raw.trim())
+    const host = parsed.hostname.replace(/^www\./, '')
+    if (!['x.com', 'twitter.com', 'x.pcstyle.dev'].includes(host) && !host.endsWith('.vercel.app')) {
+      return null
+    }
+    const match = parsed.pathname.match(/^\/([^/?#]+)\/status\/(\d+)\/?$/)
+    if (!match) return null
+    return `/${match[1]}/status/${match[2]}`
+  } catch {
+    return null
+  }
+}
 
 function setupConvertForm(root: HTMLElement) {
   const form = root.querySelector<HTMLFormElement>('[data-convert-form]')
@@ -13,222 +32,296 @@ function setupConvertForm(root: HTMLElement) {
     e.preventDefault()
     const raw = input.value.trim()
     if (!raw) return
-    const target = `/api/convert?url=${encodeURIComponent(raw)}`
-    window.open(target, '_blank', 'noopener,noreferrer')
+    const path = statusPathFromUrl(raw)
+    if (!path) return
+    window.open(path, '_blank', 'noopener,noreferrer')
   })
 }
 
-function setupReveal(root: HTMLElement) {
-  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  const nodes = root.querySelectorAll<HTMLElement>('.reveal')
-  if (reduce) {
-    nodes.forEach((el) => el.classList.add('is-visible'))
-    return
-  }
-
-  const observer = new IntersectionObserver(
-    (entries) => {
-      for (const entry of entries) {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('is-visible')
-          observer.unobserve(entry.target)
-        }
-      }
-    },
-    { threshold: 0.12, rootMargin: '0px 0px -40px 0px' },
-  )
-
-  nodes.forEach((el) => observer.observe(el))
-}
-
 app.innerHTML = `
-<div class="flex min-h-screen flex-col">
-  <header class="site-header sticky top-0 z-40">
-    <div class="container-page flex h-16 items-center justify-between">
-      <a href="/" class="flex shrink-0 items-center font-semibold tracking-tight">
-        <span class="font-mono text-lg">x.md</span>
-      </a>
-      <nav class="flex items-center gap-6">
-        <a class="nav-link font-medium text-ink" href="#docs">Docs</a>
-        <a class="nav-link" href="#agents">Agents</a>
-        <a class="nav-link" href="/api/convert?url=${encodeURIComponent(EXAMPLE_URL)}" target="_blank" rel="noreferrer">API</a>
-      </nav>
-    </div>
+<div class="x-root w-full overflow-hidden">
+  <header class="relative w-full border-b border-white/[0.08]">
+    <nav aria-label="Primary" class="mx-auto flex h-[73px] max-w-[1200px] items-center justify-between px-8">
+      <a href="#top" class="font-mono text-[17px] font-medium tracking-tight text-[#f7f8f8]">x.md</a>
+      <div class="hidden items-center gap-1 md:flex">
+        <a href="#hosted" class="nav-link h-8 px-3">Hosted</a>
+        <a href="#docs" class="nav-link h-8 px-3">Docs</a>
+        <a href="#agents" class="nav-link h-8 px-3">Agents</a>
+        <a href="#routes" class="nav-link h-8 px-3">API</a>
+      </div>
+      <div class="flex items-center gap-3">
+        <a href="https://github.com/pc-style/x-md" target="_blank" rel="noreferrer" class="nav-link hidden h-8 px-3 sm:flex">GitHub</a>
+        <a href="#convert" class="btn-primary flex h-8 items-center rounded-full px-3.5 text-[13px]">Convert a post</a>
+      </div>
+    </nav>
   </header>
 
-  <main class="flex-1">
-    <section class="container-page border-b border-border py-12 lg:py-16">
-      <div class="grid min-h-[min(100dvh,720px)] items-center gap-10 lg:grid-cols-2 lg:gap-14">
-        <div class="max-w-xl">
-          <p class="eyebrow">Self-hosted converter</p>
-          <h1 class="text-4xl font-semibold tracking-tight text-ink sm:text-5xl lg:text-[2.75rem] lg:leading-[1.08]">
+  <main id="top">
+    <section class="mx-auto max-w-[1200px] px-8 pt-[88px] pb-[120px]">
+      <div class="grid items-center gap-14 lg:grid-cols-2">
+        <div class="max-w-[520px]">
+          <p class="eyebrow eyebrow-accent mb-5">Open-source converter</p>
+          <h1 class="hero-h text-[clamp(40px,5vw,64px)] font-medium leading-[1.02] text-[#f7f8f8]">
             X posts as Markdown you can ship anywhere.
           </h1>
-          <p class="mt-4 max-w-md text-muted">
-            Open stack on Vercel: threads, media, quotes, and X Articles. No converter subscription.
+          <p class="mt-6 max-w-[440px] text-[17px] leading-[1.6] text-[#8a8f98]">
+            Use the live site at <code class="code-chip">x.pcstyle.dev</code> or deploy your own on Vercel. Threads, media, quotes, and X Articles — no paid X API keys on the default path.
           </p>
-          <div class="mt-8 flex flex-wrap gap-3">
-            <a class="btn-primary" href="#convert">Convert a post</a>
-            <a class="btn-ghost" href="#docs">Read docs</a>
+          <div class="mt-9 flex flex-wrap gap-3">
+            <a href="#convert" class="btn-primary flex h-10 items-center rounded-full px-3.5 text-[13px]">Convert a post</a>
+            <a href="#hosted" class="btn-ghost flex h-10 items-center rounded-full px-3.5 text-[13px]">How hosted works</a>
           </div>
         </div>
-        <div class="hero-preview">
-          <p class="border-b border-[#2a3348] px-4 py-2.5 font-mono text-[11px] text-[#8b95a8]">curl -s -H "Accept: text/markdown" \\</p>
-          <pre class="m-0 overflow-auto px-4 py-4 font-mono text-[12px] leading-6 text-[#c8d0e0]">  "/api/convert?url=…"
 
-# trq212 (@trq212)
+        <div class="hero-terminal">
+          <div class="flex items-center gap-2 border-b border-white/[0.06] px-4 py-3">
+            <span class="h-3 w-3 rounded-full bg-[#232326]"></span>
+            <span class="h-3 w-3 rounded-full bg-[#232326]"></span>
+            <span class="h-3 w-3 rounded-full bg-[#232326]"></span>
+            <span class="ml-2 font-mono text-[11px] text-[#62666d]">swap the host</span>
+          </div>
+          <pre class="m-0 overflow-x-auto px-5 py-5 font-mono text-[12.5px] leading-[1.7] text-[#d0d6e0]"><span class="text-[#62666d]"># x.com post</span>
+<span class="text-[#8a8f98]">https://x.com/${EXAMPLE_HANDLE}/status/…</span>
 
-Source: https://x.com/trq212/status/…
-Stats: 2.1K likes · 412 reposts
+<span class="text-[#62666d]"># same path on x.md → Markdown in the browser</span>
+<span class="text-[#7170ff]">${EXAMPLE_HOSTED_URL}</span>
 
-Full article body when FxTwitter
-returns X Article blocks…</pre>
+<span class="text-[#62666d]"># trq212 (@trq212)</span>
+
+<span class="text-[#8a8f98]">Source:</span> https://x.com/${EXAMPLE_HANDLE}/status/…
+<span class="text-[#8a8f98]">Stats:</span> 2.1K likes · 412 reposts</pre>
         </div>
       </div>
     </section>
 
-    <section id="convert" class="section-surface py-14">
-      <div class="container-page reveal">
-        <div class="mx-auto max-w-xl">
-          <h2 class="section-title">Convert a post</h2>
-          <p class="mt-2 text-muted">Paste any public X status URL. Opens Markdown in a new tab.</p>
-          <form data-convert-form class="mt-6 flex flex-col gap-3 sm:flex-row">
-            <input
-              data-convert-input
-              type="url"
-              name="url"
-              required
-              placeholder="https://x.com/handle/status/…"
-              value="${EXAMPLE_URL}"
-              class="convert-input min-w-0 flex-1"
-              autocomplete="off"
-              spellcheck="false"
-            />
-            <button type="submit" class="btn-primary shrink-0">Get Markdown</button>
-          </form>
-          <p class="mt-4 text-sm text-muted">
-            Or call <code>GET /api/convert?url=…</code> with <code>Accept: text/markdown</code>.
-          </p>
-        </div>
+    <section id="convert" class="mx-auto max-w-[1200px] px-8 pb-[120px]">
+      <div class="convert-card mx-auto max-w-[620px]">
+        <p class="eyebrow eyebrow-accent mb-3">Try it</p>
+        <h2 class="text-[28px] font-medium leading-tight text-[#f7f8f8]">Convert a post</h2>
+        <p class="mt-2 text-[16px] text-[#8a8f98]">Paste any public X status URL. Opens Markdown at the same path on this site.</p>
+        <form data-convert-form class="mt-7 flex flex-col gap-3 sm:flex-row">
+          <label for="x-url" class="sr-only">X status URL</label>
+          <input
+            id="x-url"
+            data-convert-input
+            type="url"
+            name="url"
+            required
+            inputmode="url"
+            autocomplete="off"
+            spellcheck="false"
+            placeholder="https://x.com/handle/status/…"
+            value="${EXAMPLE_X_URL}"
+            class="convert-input"
+          />
+          <button type="submit" class="btn-primary flex h-[42px] shrink-0 items-center justify-center rounded-full px-4 text-[13px]">Get Markdown</button>
+        </form>
+        <p class="mt-4 text-[14px] text-[#8a8f98]">
+          Opens <code class="code-chip">${EXAMPLE_PATH}</code> here — the same trick as swapping <code class="code-chip">x.com</code> → <code class="code-chip">x.pcstyle.dev</code> in the link.
+        </p>
       </div>
     </section>
 
-    <section id="docs" class="container-narrow py-16">
-      <div class="reveal mb-12">
-        <p class="eyebrow">Documentation</p>
-        <h2 class="section-title">Setup and API</h2>
-        <p class="mt-3 text-muted">Deploy on Vercel, wire agents, and tune output with query params.</p>
+    <section id="docs" class="mx-auto max-w-[920px] px-8 pb-[120px]">
+      <div class="mb-14 max-w-[560px]">
+        <p class="eyebrow eyebrow-accent mb-3">Documentation</p>
+        <h2 class="text-[clamp(32px,4vw,48px)] font-medium leading-[1.05] tracking-[-0.03em] text-[#f7f8f8]">Setup and API</h2>
+        <p class="mt-4 text-[17px] leading-[1.6] text-[#8a8f98]">Use the hosted converter as-is, or fork and deploy your own stack on Vercel.</p>
       </div>
 
-      <div class="info-banner reveal mb-12">
-        <strong>Provider chain included:</strong> FxTwitter for rich data, X syndication as fallback,
-        optional Firecrawl when you set <code>FIRECRAWL_API_KEY</code>.
+      <article id="hosted" class="mb-16">
+        <p class="eyebrow eyebrow-muted mb-3">Hosted</p>
+        <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">How x.pcstyle.dev works</h3>
+        <p class="mt-3 max-w-[640px] text-[16px] leading-relaxed text-[#8a8f98]">
+          The public deploy is a read-only converter. Take any X status link and replace the host — keep the path identical:
+        </p>
+        <pre class="code-block mt-6">https://x.com/${EXAMPLE_HANDLE}/status/${EXAMPLE_ID}
+        ↓
+${EXAMPLE_HOSTED_URL}</pre>
+        <p class="mt-4 text-[16px] leading-relaxed text-[#8a8f98]">
+          Append query params the same way: <code class="code-chip">?format=obsidian</code>, <code class="code-chip">?thread=full</code>, <code class="code-chip">?userinfo=author</code>.
+        </p>
+        <div class="mt-8 grid gap-4 sm:grid-cols-2">
+          <div class="compare-tile">
+            <h4>Hosted (x.pcstyle.dev)</h4>
+            <ul class="mt-3 space-y-2 text-[14px] leading-relaxed text-[#8a8f98]">
+              <li>FxTwitter primary, X syndication fallback</li>
+              <li>Cached responses (about 1 hour by default)</li>
+              <li>CORS open on <code class="code-chip">/api/*</code> for agents</li>
+              <li><strong class="text-[#f7f8f8]">No Firecrawl</strong> — not configured on production</li>
+            </ul>
+          </div>
+          <div class="compare-tile">
+            <h4>Self-host (your Vercel project)</h4>
+            <ul class="mt-3 space-y-2 text-[14px] leading-relaxed text-[#8a8f98]">
+              <li>Same FxTwitter + syndication chain</li>
+              <li>Optional <code class="code-chip">FIRECRAWL_API_KEY</code> scrape fallback</li>
+              <li>Your cache TTL and env vars</li>
+              <li>Same URL swap on your domain</li>
+            </ul>
+          </div>
+        </div>
+        <p class="mt-4 text-[14px] text-[#62666d]">
+          <code class="code-chip">X-Source</code> is <code class="code-chip">fxtwitter</code> or <code class="code-chip">syndication</code> on the hosted site. Self-host only adds <code class="code-chip">firecrawl</code> when the key is set.
+        </p>
+      </article>
+
+      <div class="info-banner mb-16">
+        <strong class="font-medium text-[#f7f8f8]">Provider chain:</strong> FxTwitter for rich data, X syndication as fallback.
+        <span class="text-[#8a8f98]"> Firecrawl is </span>
+        <strong class="font-medium text-[#f7f8f8]">self-host only</strong>
+        <span class="text-[#8a8f98]"> — set </span>
+        <code class="code-chip text-[#f7f8f8]">FIRECRAWL_API_KEY</code>
+        <span class="text-[#8a8f98]"> on your own deploy; it is not enabled on x.pcstyle.dev.</span>
       </div>
 
-      <article class="reveal mb-16 grid gap-8 border-t border-border pt-12 lg:grid-cols-[1fr_1.1fr] lg:items-start" id="routes">
+      <article id="routes" class="mb-16 grid gap-8 border-t border-[#23252a] pt-12 lg:grid-cols-[1fr_1.1fr] lg:items-start">
         <div>
-          <p class="eyebrow">HTTP</p>
-          <h3 class="section-title text-2xl">Routes</h3>
-          <p class="mt-3 text-muted">
-            <code>/api/convert</code> takes an encoded status URL. Path-style
-            <code>/:handle/status/:id</code> works when rewrites are configured on Vercel.
+          <p class="eyebrow eyebrow-muted mb-3">HTTP</p>
+          <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">Routes</h3>
+          <p class="mt-3 text-[16px] leading-relaxed text-[#8a8f98]">
+            Path-style is the usual way: <code class="code-chip">/:handle/status/:id</code> returns Markdown in the browser. Vercel rewrites map it to the converter.
           </p>
-          <p class="mt-4 text-sm text-muted">Responses are Markdown by default (plain text, not JSON).</p>
+          <p class="mt-4 text-[16px] leading-relaxed text-[#8a8f98]">
+            <code class="code-chip">/api/convert?url=…</code> still works when you need an encoded URL (agents, curl, tools that only accept query strings).
+          </p>
+          <p class="mt-4 text-[14px] text-[#62666d]">Responses are Markdown by default (plain text, not JSON).</p>
         </div>
-        <pre class="code-block m-0">GET /api/convert?url=https%3A%2F%2Fx.com%2F…
+        <pre class="code-block">GET ${EXAMPLE_PATH}
 Accept: text/markdown
 
-# handle (@handle)
+# ${EXAMPLE_HANDLE} (@${EXAMPLE_HANDLE})
 …</pre>
       </article>
 
-      <article class="reveal mb-16 border-t border-border pt-12" id="agents">
-        <p class="eyebrow">Automation</p>
-        <h3 class="section-title text-2xl">AI agents</h3>
-        <p class="mt-3 max-w-2xl text-muted">Point tools at <code>https://x.pcstyle.dev/api/convert</code> with a full X link, or use repo skills under <code>skills/read-x-links-*</code>.</p>
-        <pre class="code-block mt-6">curl -sS -G "https://x.pcstyle.dev/api/convert" \\
-  --data-urlencode "url=${EXAMPLE_URL}" \\
+      <article id="agents" class="mb-16 border-t border-[#23252a] pt-12">
+        <p class="eyebrow eyebrow-muted mb-3">Automation</p>
+        <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">AI agents</h3>
+        <p class="mt-3 max-w-[640px] text-[16px] leading-relaxed text-[#8a8f98]">
+          Easiest path: swap the host and fetch Markdown. For tools that need a single URL param, use <code class="code-chip">/api/convert?url=…</code>. Repo skills live under <code class="code-chip">skills/read-x-links-*</code>.
+        </p>
+        <pre class="code-block mt-6"># path-style (preferred)
+curl -sS -H "Accept: text/markdown" \\
+  "${EXAMPLE_HOSTED_URL}?thread=full"
+
+# query-style (agents / encoded URLs)
+curl -sS -G "https://x.pcstyle.dev/api/convert" \\
+  --data-urlencode "url=${EXAMPLE_X_URL}" \\
   -H "Accept: text/markdown"</pre>
-        <p class="mt-4 text-sm text-muted">JSON: <code>Accept: application/json</code> includes <code>source</code> (fxtwitter | syndication | firecrawl).</p>
+        <p class="mt-4 text-[14px] text-[#62666d]">
+          JSON: <code class="code-chip">Accept: application/json</code> includes <code class="code-chip">source</code> (<code class="code-chip">fxtwitter</code> | <code class="code-chip">syndication</code> on hosted; <code class="code-chip">firecrawl</code> only on self-host with the key set).
+        </p>
       </article>
 
-      <article class="reveal mb-16 border-t border-border pt-12" id="params">
-        <p class="eyebrow">API</p>
-        <h3 class="section-title text-2xl">Query params</h3>
-        <p class="mt-3 text-muted">Append to <code>/api/convert?url=…</code> or path routes.</p>
-        <div class="mt-6 overflow-x-auto rounded-xl border border-border">
-          <table class="docs-table m-0 border-0">
-            <thead><tr><th>Param</th><th>Default</th><th>Values</th></tr></thead>
+      <article id="params" class="mb-16 border-t border-[#23252a] pt-12">
+        <p class="eyebrow eyebrow-muted mb-3">API</p>
+        <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">Query params</h3>
+        <p class="mt-3 text-[16px] leading-relaxed text-[#8a8f98]">
+          Append to path URLs or <code class="code-chip">/api/convert?url=…</code>.
+        </p>
+        <div class="mt-6 overflow-x-auto rounded-xl border border-[#23252a]">
+          <table class="docs-table">
+            <thead>
+              <tr>
+                <th>Param</th>
+                <th>Default</th>
+                <th>Values</th>
+              </tr>
+            </thead>
             <tbody>
-              <tr><td><code>format</code></td><td>markdown</td><td><code>markdown</code>, <code>obsidian</code></td></tr>
-              <tr><td><code>thread</code></td><td>off</td><td><code>off</code>, <code>full</code>, <code>2-100</code></td></tr>
-              <tr><td><code>userinfo</code></td><td>off</td><td><code>off</code>, <code>author</code>, <code>all</code></td></tr>
-              <tr><td><code>url</code></td><td>-</td><td>Encoded X status URL (required on <code>/api/convert</code>)</td></tr>
+              <tr>
+                <td><code>format</code></td>
+                <td>markdown</td>
+                <td class="font-mono text-[12px]">markdown, obsidian</td>
+              </tr>
+              <tr>
+                <td><code>thread</code></td>
+                <td>off</td>
+                <td class="font-mono text-[12px]">off, full, 2-100</td>
+              </tr>
+              <tr>
+                <td><code>userinfo</code></td>
+                <td>off</td>
+                <td class="font-mono text-[12px]">off, author, all</td>
+              </tr>
+              <tr>
+                <td><code>url</code></td>
+                <td>—</td>
+                <td class="text-[#d0d6e0]">Encoded X status URL (<code class="code-chip">/api/convert</code> only; path routes omit this)</td>
+              </tr>
             </tbody>
           </table>
         </div>
       </article>
 
-      <article class="reveal mb-16 border-t border-border pt-12" id="formats">
-        <p class="eyebrow">Output</p>
-        <h3 class="section-title text-2xl">Output formats</h3>
-        <p class="mt-3 text-muted">Use <code>?format=</code> on any convert URL. Omit for markdown.</p>
-        <div class="mt-8 grid gap-4 sm:grid-cols-2">
+      <article id="formats" class="mb-16 border-t border-[#23252a] pt-12">
+        <p class="eyebrow eyebrow-muted mb-3">Output</p>
+        <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">Output formats</h3>
+        <p class="mt-3 text-[16px] leading-relaxed text-[#8a8f98]">
+          Use <code class="code-chip">?format=</code> on any convert URL. Omit for markdown.
+        </p>
+        <div class="mt-7 grid gap-4 sm:grid-cols-2">
           <div class="format-tile">
-            <strong class="text-lg font-semibold"><code>markdown</code></strong>
-            <p class="mt-2 text-sm text-muted">Notes with author, stats, media, quotes, and X Article bodies when available.</p>
+            <strong class="font-mono text-[15px] font-medium text-[#55ccff]">markdown</strong>
+            <p class="mt-2 text-[14px] leading-relaxed text-[#8a8f98]">Notes with author, stats, media, quotes, and X Article bodies when available.</p>
           </div>
           <div class="format-tile">
-            <strong class="text-lg font-semibold"><code>obsidian</code></strong>
-            <p class="mt-2 text-sm text-muted">Vault import with YAML frontmatter and per-post headings.</p>
+            <strong class="font-mono text-[15px] font-medium text-[#55ccff]">obsidian</strong>
+            <p class="mt-2 text-[14px] leading-relaxed text-[#8a8f98]">Vault import with YAML frontmatter and per-post headings.</p>
           </div>
         </div>
-        <p class="mt-4 text-sm text-muted">Media uses public X preview URLs in the output file.</p>
+        <p class="mt-4 text-[14px] text-[#62666d]">Media uses public X preview URLs in the output file.</p>
       </article>
 
-      <article class="reveal mb-16 border-t border-border pt-12" id="articles">
-        <p class="eyebrow">Long form</p>
-        <h3 class="section-title text-2xl">X Articles</h3>
-        <p class="mt-3 text-muted">Long-form posts use the normal status URL. Article text is pulled from X Article blocks when the primary provider returns them.</p>
-        <pre class="code-block mt-6">${EXAMPLE_URL}?format=markdown&amp;thread=full</pre>
+      <article id="articles" class="mb-16 border-t border-[#23252a] pt-12">
+        <p class="eyebrow eyebrow-muted mb-3">Long form</p>
+        <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">X Articles</h3>
+        <p class="mt-3 max-w-[640px] text-[16px] leading-relaxed text-[#8a8f98]">
+          Long-form posts use the normal status URL. Article text is pulled from X Article blocks when FxTwitter returns them (syndication fallback may omit article body).
+        </p>
+        <pre class="code-block mt-6">${EXAMPLE_HOSTED_URL}?format=markdown&amp;thread=full</pre>
       </article>
 
-      <article class="reveal border-t border-border pt-12" id="deploy">
-        <p class="eyebrow">Infrastructure</p>
-        <h3 class="section-title text-2xl">Deployment</h3>
-        <p class="mt-3 text-muted">Bun build, Vercel Hobby, env vars in <code>.env.local</code>. You run the stack, not a hosted SaaS tier.</p>
-        <div class="mt-8">
+      <article id="deploy" class="border-t border-[#23252a] pt-12">
+        <p class="eyebrow eyebrow-muted mb-3">Infrastructure</p>
+        <h3 class="text-[24px] font-semibold leading-tight text-[#f7f8f8]">Self-host on Vercel</h3>
+        <p class="mt-3 max-w-[640px] text-[16px] leading-relaxed text-[#8a8f98]">
+          Fork the repo, deploy to Vercel, and optionally add env vars in <code class="code-chip">.env.local</code>. Your instance gets the same path-style URLs on your domain.
+        </p>
+        <div class="mt-7 space-y-0">
           <div class="provider-row">
-            <strong class="text-lg font-semibold">FxTwitter</strong>
-            <span class="text-sm text-muted">Primary: threads, media, articles</span>
+            <strong class="text-[17px] font-medium text-[#f7f8f8]">FxTwitter</strong>
+            <span class="text-[14px] text-[#8a8f98]">Primary — threads, media, articles (hosted + self-host)</span>
           </div>
           <div class="provider-row">
-            <strong class="text-lg font-semibold">Syndication</strong>
-            <span class="text-sm text-muted">X CDN fallback for single posts</span>
+            <strong class="text-[17px] font-medium text-[#f7f8f8]">Syndication</strong>
+            <span class="text-[14px] text-[#8a8f98]">X CDN fallback for single posts (hosted + self-host)</span>
           </div>
           <div class="provider-row">
-            <strong class="text-lg font-semibold">Firecrawl</strong>
-            <span class="text-sm text-muted">Optional scrape if APIs fail</span>
+            <strong class="text-[17px] font-medium text-[#f7f8f8]">Firecrawl</strong>
+            <span class="text-[14px] text-[#8a8f98]">Self-host only — optional scrape when you set <code class="code-chip">FIRECRAWL_API_KEY</code></span>
           </div>
         </div>
-        <p class="mt-6 text-sm text-muted">Header <code>X-Source</code> reports which provider handled the request.</p>
+        <div class="info-banner-muted mt-6">
+          The live site at <code class="code-chip">x.pcstyle.dev</code> runs FxTwitter + syndication only. Firecrawl is documented for self-hosted deploys and is not configured in production.
+        </div>
       </article>
     </section>
   </main>
 
-  <footer class="site-footer">
-    <div class="container-page flex flex-col gap-4 py-10 text-sm text-muted sm:flex-row sm:items-center sm:justify-between">
-      <div class="flex flex-wrap gap-5">
-        <a href="https://github.com/pc-style/x-md" target="_blank" rel="noreferrer" class="hover:text-ink">GitHub</a>
-        <a href="/" class="hover:text-ink">x.md</a>
-        <a href="#docs" class="hover:text-ink">Docs</a>
-        <a href="/api/convert?url=${encodeURIComponent(EXAMPLE_URL)}" target="_blank" rel="noreferrer" class="hover:text-ink">API</a>
+  <footer class="border-t border-[#23252a] bg-[#08090a]">
+    <div class="mx-auto flex max-w-[1200px] flex-col gap-4 px-8 py-10 text-[14px] text-[#8a8f98] sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex flex-wrap items-center gap-6">
+        <a href="https://github.com/pc-style/x-md" target="_blank" rel="noreferrer" class="footer-link">GitHub</a>
+        <a href="#top" class="footer-link font-mono">x.md</a>
+        <a href="#hosted" class="footer-link">Hosted</a>
+        <a href="#docs" class="footer-link">Docs</a>
+        <a href="#routes" class="footer-link">API</a>
       </div>
-      <p>Not affiliated with X Corp.</p>
+      <p class="text-[#62666d]">Not affiliated with X Corp.</p>
     </div>
   </footer>
 </div>
 `
 
 setupConvertForm(app)
-setupReveal(app)

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,11 +8,20 @@ const EXAMPLE_X_URL = `https://x.com/${EXAMPLE_HANDLE}/status/${EXAMPLE_ID}`
 const EXAMPLE_HOSTED_URL = `https://x.pcstyle.dev/${EXAMPLE_HANDLE}/status/${EXAMPLE_ID}`
 const EXAMPLE_PATH = `/${EXAMPLE_HANDLE}/status/${EXAMPLE_ID}`
 
+const HOSTED_HOSTS = new Set([
+  'x.pcstyle.dev',
+  typeof window !== 'undefined' ? window.location.hostname.replace(/^www\./, '') : '',
+])
+
 function statusPathFromUrl(raw: string): string | null {
   try {
     const parsed = new URL(raw.trim())
     const host = parsed.hostname.replace(/^www\./, '')
-    if (!['x.com', 'twitter.com', 'x.pcstyle.dev'].includes(host) && !host.endsWith('.vercel.app')) {
+    if (
+      !['x.com', 'twitter.com'].includes(host) &&
+      !HOSTED_HOSTS.has(host) &&
+      !host.endsWith('.vercel.app')
+    ) {
       return null
     }
     const match = parsed.pathname.match(/^\/([^/?#]+)\/status\/(\d+)\/?$/)

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap");
+@import "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap";
 @import "tailwindcss";
 
 :root {
@@ -226,6 +226,6 @@
 
   .sr-only {
     @apply absolute m-[-1px] h-px w-px overflow-hidden border-0 p-0 whitespace-nowrap;
-    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
   }
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,259 +1,231 @@
-@import url("https://fonts.bunny.net/css?family=ibm-plex-sans:400,500,600,700|ibm-plex-mono:400,500,600");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap");
 @import "tailwindcss";
 
 :root {
-  --ink: #0c0f14;
-  --muted: #5c6578;
-  --border: #e2e6ef;
-  --surface: #f4f6fa;
-  --page: #ffffff;
-  --accent: #0b7a72;
-  --accent-hover: #096860;
-  --accent-bright: #0b7a72;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --ink: #eef1f7;
-    --muted: #b8c0d0;
-    --border: #343f54;
-    --surface: #151b28;
-    --page: #0c0f14;
-    --accent: #3dd4c8;
-    --accent-hover: #5ce0d6;
-    --accent-bright: #6ee8de;
-  }
+  --surface: #08090a;
+  --surface-raised: #0f1011;
+  --on: #f7f8f8;
+  --on-2: #d0d6e0;
+  --on-3: #8a8f98;
+  --on-4: #62666d;
+  --hair: rgba(255, 255, 255, 0.06);
+  --hair-strong: rgba(255, 255, 255, 0.08);
+  --border: #23252a;
+  --accent: #7170ff;
+  --accent-cyan: #55ccff;
 }
 
 @theme {
-  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter", "SF Pro Display", -apple-system, system-ui, sans-serif;
   --font-mono: "IBM Plex Mono", ui-monospace, monospace;
-  --color-ink: var(--ink);
-  --color-muted: var(--muted);
-  --color-border: var(--border);
-  --color-surface: var(--surface);
-  --color-page: var(--page);
-  --color-accent: var(--accent);
-  --color-accent-hover: var(--accent-hover);
-  --color-accent-bright: var(--accent-bright);
 }
 
 @layer base {
   html {
     scroll-behavior: smooth;
-    color-scheme: light dark;
+    color-scheme: dark;
   }
 
   body {
-    @apply m-0 min-h-screen font-sans text-[15px] leading-relaxed antialiased;
-    background-color: var(--page);
-    color: var(--ink);
+    @apply m-0 min-h-screen font-sans antialiased;
+    background-color: var(--surface);
+    color: var(--on);
   }
 
   a {
-    @apply text-inherit;
+    @apply text-inherit no-underline;
   }
 
-  code {
-    @apply rounded px-1.5 py-0.5 font-mono text-[0.88em];
-    background-color: var(--surface);
-    color: var(--ink);
+  h1,
+  h2,
+  h3 {
+    letter-spacing: -0.02em;
   }
 }
 
 @layer components {
-  .container-page {
-    @apply mx-auto w-full max-w-6xl px-4 sm:px-6;
+  .x-root a,
+  .x-root button,
+  .x-root input {
+    transition: all 160ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
   }
 
-  .container-narrow {
-    @apply mx-auto w-full max-w-3xl px-4 sm:px-6;
+  .x-root a:focus-visible,
+  .x-root button:focus-visible,
+  .x-root input:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 6px;
   }
 
-  .nav-link {
-    @apply text-sm transition-colors duration-200;
-    color: var(--muted);
-  }
-
-  .nav-link:hover {
-    color: var(--ink);
-  }
-
-  .btn-primary {
-    @apply inline-flex items-center justify-center rounded-lg px-4 py-2.5 text-sm font-medium transition active:scale-[0.98];
-    background-color: var(--accent);
-    color: #ffffff;
-  }
-
-  .btn-primary:hover {
-    background-color: var(--accent-hover);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .btn-primary {
-      color: #0c0f14;
-    }
-  }
-
-  .btn-ghost {
-    @apply inline-flex items-center justify-center rounded-lg px-4 py-2.5 text-sm font-medium transition active:scale-[0.98];
-    border: 1px solid var(--border);
-    color: var(--ink);
-  }
-
-  .btn-ghost:hover {
-    border-color: var(--muted);
+  .hero-h {
+    letter-spacing: -0.035em;
   }
 
   .eyebrow {
-    @apply mb-3 text-xs font-medium tracking-wide uppercase;
-    color: var(--accent-bright);
+    letter-spacing: 0.06em;
   }
 
-  .section-title {
-    @apply text-2xl font-semibold tracking-tight sm:text-3xl;
-    color: var(--ink);
+  .eyebrow-accent {
+    @apply text-[12px] font-medium uppercase;
+    color: var(--accent);
   }
 
-  .docs-table {
-    @apply my-4 w-full border-collapse text-sm;
+  .eyebrow-muted {
+    @apply text-[12px] font-medium uppercase;
+    color: var(--on-4);
   }
 
-  .docs-table th,
-  .docs-table td {
-    @apply px-3 py-2.5 text-left align-top;
-    border: 1px solid var(--border);
-    color: var(--ink);
+  .btn-primary {
+    @apply inline-flex items-center justify-center font-medium;
+    background-color: #e5e5e6;
+    color: #08090a;
+    box-shadow:
+      0 1px 1px rgba(0, 0, 0, 0.08),
+      0 0 1px rgba(0, 0, 0, 0.08);
   }
 
-  .docs-table th {
-    @apply font-medium;
-    background-color: var(--surface);
+  .btn-primary:hover {
+    background-color: #ffffff;
+  }
+
+  .btn-ghost {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: var(--on);
+  }
+
+  .btn-ghost:hover {
+    background-color: rgba(255, 255, 255, 0.09);
+  }
+
+  .nav-link {
+    @apply inline-flex items-center rounded-full text-[13px];
+    color: var(--on-3);
+  }
+
+  .nav-link:hover {
+    color: var(--on);
+    background-color: rgba(255, 255, 255, 0.06);
+  }
+
+  .code-chip {
+    @apply rounded font-mono text-[12px];
+    background-color: rgba(255, 255, 255, 0.05);
+    padding: 2px 6px;
+    color: var(--on-2);
   }
 
   .code-block {
-    @apply my-4 overflow-x-auto rounded-xl px-4 py-3 font-mono text-[13px] leading-6 whitespace-pre;
-    border: 1px solid var(--border);
-    background-color: #0c0f14;
-    color: #d4dae8;
+    @apply m-0 overflow-x-auto rounded-xl border px-4 py-4 font-mono text-[12.5px] leading-[1.7] whitespace-pre;
+    border-color: var(--hair);
+    background-color: var(--surface-raised);
+    color: var(--on-2);
   }
 
   .info-banner {
-    @apply rounded-xl px-4 py-3 text-sm;
-    border: 1px solid #b8e8e4;
-    background-color: #ecf9f7;
-    color: #0a4a45;
+    @apply rounded-xl border px-5 py-4 text-[15px] leading-relaxed;
+    border-color: rgba(113, 112, 255, 0.25);
+    background-color: rgba(113, 112, 255, 0.06);
+    color: var(--on-2);
   }
 
-  @media (prefers-color-scheme: dark) {
-    .info-banner {
-      border-color: #2a5c56;
-      background-color: #122824;
-      color: #b8f0e8;
-    }
+  .info-banner-muted {
+    @apply rounded-xl border px-5 py-4 text-[15px] leading-relaxed;
+    border-color: var(--hair);
+    background-color: var(--surface-raised);
+    color: var(--on-3);
+  }
+
+  .compare-tile {
+    @apply rounded-xl border p-5;
+    border-color: var(--hair);
+    background-color: var(--surface-raised);
+  }
+
+  .compare-tile h4 {
+    @apply text-[15px] font-semibold;
+    color: var(--on);
   }
 
   .convert-input {
-    @apply min-w-0 flex-1 rounded-lg px-3 py-2.5 font-mono text-sm outline-none transition;
-    border: 1px solid var(--border);
-    background-color: var(--page);
-    color: var(--ink);
+    @apply min-w-0 flex-1 rounded-lg border px-3.5 py-2.5 font-mono text-[13px] outline-none;
+    border-color: var(--border);
+    background-color: var(--surface);
+    color: var(--on);
   }
 
   .convert-input::placeholder {
-    color: var(--muted);
+    color: var(--on-4);
   }
 
   .convert-input:focus {
     border-color: var(--accent);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
   }
 
-  .provider-row {
-    @apply flex flex-col gap-1 py-4 pl-5 sm:flex-row sm:items-baseline sm:justify-between sm:gap-6;
-    border-left: 2px solid var(--accent);
+  .hero-terminal {
+    @apply overflow-hidden rounded-2xl border;
+    border-color: var(--hair);
+    background-color: var(--surface-raised);
   }
 
-  .provider-row + .provider-row {
-    @apply pt-6;
-    border-top: 1px solid var(--border);
-  }
-
-  .provider-row strong {
-    color: var(--ink);
+  .convert-card {
+    @apply rounded-2xl border p-10;
+    border-color: var(--hair);
+    background-color: var(--surface-raised);
   }
 
   .format-tile {
-    @apply rounded-xl p-5 transition;
-    border: 1px solid var(--border);
-    background-color: var(--page);
+    @apply rounded-xl border p-6;
+    border-color: var(--hair);
+    background-color: var(--surface-raised);
   }
 
-  .format-tile:hover {
-    border-color: var(--muted);
+  .provider-row {
+    @apply flex flex-col gap-1 border-l-2 py-4 pl-5 sm:flex-row sm:items-baseline sm:justify-between;
+    border-left-color: var(--accent);
   }
 
-  .format-tile strong {
-    color: var(--ink);
+  .provider-row + .provider-row {
+    @apply border-t;
+    border-top-color: var(--border);
   }
 
-  .hero-preview {
-    @apply overflow-hidden rounded-xl;
-    border: 1px solid var(--border);
-    background-color: #0c0f14;
-    box-shadow: 0 24px 64px -12px rgba(12, 15, 20, 0.18);
+  .docs-table {
+    @apply w-full border-collapse text-[14px];
   }
 
-  @media (prefers-color-scheme: dark) {
-    .hero-preview {
-      box-shadow: 0 24px 64px -12px rgba(0, 0, 0, 0.45);
-    }
+  .docs-table th {
+    @apply border-b px-4 py-3 text-left font-medium;
+    border-color: var(--border);
+    background-color: var(--surface-raised);
+    color: var(--on);
   }
 
-  .reveal {
-    opacity: 0;
-    transform: translateY(20px);
-    transition:
-      opacity 0.55s cubic-bezier(0.16, 1, 0.3, 1),
-      transform 0.55s cubic-bezier(0.16, 1, 0.3, 1);
+  .docs-table td {
+    @apply border-b px-4 py-3;
+    border-color: var(--border);
+    color: var(--on-2);
   }
 
-  .reveal.is-visible {
-    opacity: 1;
-    transform: translateY(0);
+  .docs-table tr:last-child td {
+    @apply border-b-0;
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .reveal {
-      opacity: 1;
-      transform: none;
-      transition: none;
-    }
+  .docs-table td:nth-child(2) {
+    color: var(--on-3);
   }
 
-  .site-header {
-    @apply sticky top-0 z-40 backdrop-blur-md;
-    border-bottom: 1px solid var(--border);
-    background-color: color-mix(in srgb, var(--page) 92%, transparent);
+  .docs-table code {
+    @apply bg-transparent p-0 font-mono text-[12px];
+    color: var(--accent-cyan);
   }
 
-  .site-footer {
-    border-top: 1px solid var(--border);
-    background-color: var(--surface);
-    color: var(--muted);
+  .footer-link:hover {
+    color: var(--on);
   }
 
-  .site-footer a:hover {
-    color: var(--ink);
-  }
-
-  .section-surface {
-    border-bottom: 1px solid var(--border);
-    background-color: var(--surface);
-  }
-
-  .link-accent {
-    @apply font-medium underline-offset-2 hover:underline;
-    color: var(--accent-bright);
+  .sr-only {
+    @apply absolute m-[-1px] h-px w-px overflow-hidden border-0 p-0 whitespace-nowrap;
+    clip: rect(0, 0, 0, 0);
   }
 }

--- a/src/vite-api-plugin.ts
+++ b/src/vite-api-plugin.ts
@@ -1,6 +1,12 @@
+import type { Connect } from 'vite'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Plugin } from 'vite'
-import { ConvertError, convertTweet, markdownResponse } from '../lib/converter'
+import {
+  acceptPrefersHtml,
+  ConvertError,
+  convertTweet,
+  markdownResponse,
+} from '../lib/converter'
 
 async function handleConvert(
   url: URL,
@@ -23,6 +29,7 @@ async function handleConvert(
 
   const accept = String(req.headers.accept ?? '')
   const asJson = accept.includes('application/json')
+  const asHtml = acceptPrefersHtml(accept)
 
   try {
     const result = await convertTweet({
@@ -35,7 +42,7 @@ async function handleConvert(
       nocache: url.searchParams.get('nocache'),
     })
 
-    const { status, headers, body } = markdownResponse(result, asJson)
+    const { status, headers, body } = markdownResponse(result, asJson, asHtml)
     res.statusCode = status
     for (const [key, value] of Object.entries(headers)) {
       res.setHeader(key, value)
@@ -61,16 +68,33 @@ async function handleConvert(
   return true
 }
 
-export function apiDevPlugin(): Plugin {
-  return {
-    name: 'x-md-api-dev',
-    configureServer(server) {
-      server.middlewares.use(async (req, res, next) => {
-        if (!req.url) return next()
+function installConvertMiddleware(middlewares: Connect.Server) {
+  middlewares.use((req, res, next) => {
+    void (async () => {
+      try {
+        if (!req.url) {
+          next()
+          return
+        }
         const url = new URL(req.url, 'http://localhost')
         const handled = await handleConvert(url, req, res)
         if (!handled) next()
-      })
+      } catch (error) {
+        next(error as Error)
+      }
+    })()
+  })
+}
+
+export function apiDevPlugin(): Plugin {
+  return {
+    name: 'x-md-api-dev',
+    enforce: 'pre',
+    configureServer(server) {
+      installConvertMiddleware(server.middlewares)
+    },
+    configurePreviewServer(server) {
+      installConvertMiddleware(server.middlewares)
     },
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the landing page with a Linear-style dark UI (Inter, purple accent, pill buttons, terminal hero).
- Documents how the hosted converter actually works: swap `x.com` → `x.pcstyle.dev` on the same path instead of relying on `/api/convert?url=…`.
- Clarifies that **Firecrawl is self-host only** — production at x.pcstyle.dev runs FxTwitter + syndication.
- Convert form now opens path-style URLs (`/handle/status/id`); `/api/convert` remains documented for agents and curl.

## Test plan
- [x] `bun run build` passes
- [x] `bun run dev` — hero, convert form, and docs sections render correctly
- [x] Paste an x.com status URL in the convert form → opens Markdown at `/handle/status/id`
- [x] Hosted vs self-host comparison and Firecrawl callouts read clearly
- [x] Path-style example URLs work on preview deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the landing page with a Linear-style dark theme and clearer hosted-service docs. Path-style host swap is now the default with a fallback to `/api/convert`; adds browser-friendly HTML responses and fixes dev/preview path routes.

- **New Features**
  - Linear dark UI: Inter, purple accent, pill buttons, terminal-style hero; dark-only.
  - Path routes by default (`/:handle/status/:id?thread=full`) with safe fallback to `/api/convert?url=…`.
  - Hosted docs: swap `x.com` → `x.pcstyle.dev`; FxTwitter + syndication on hosted; `FIRECRAWL_API_KEY` is self-host only.
  - Agents and API: `npx skills add` for `read-x-links-vercel`/`read-x-links-local`; clearer params (incl. `conversation`); Markdown by default with HTML when browsers send `Accept: text/html`.

- **Bug Fixes**
  - URL parser accepts the current hostname and `.vercel.app` for self-hosted path routes.
  - Serve path-style convert routes in Vite dev and preview; middleware made more robust.
  - CSS/a11y polish: Inter import, improved `sr-only` clip-path, small lint fixes.

<sup>Written for commit c07eee5ddf593ffff40b8c8d95000c15fcb9246e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pc-style/x-md/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

