### PR TITLE
[codex] Add Discord, Telegram, and Slack Open Graph embeds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 - Landing copy frame (per Theo feedback): "Tweets are just markdown now", what-you-see vs what-your-agent-sees curl comparison in the bento under `#how`, skill install under `#agents`. No tech-stack/provider-chain talk on the landing page.
 - Homepage motion uses GSAP + ScrollTrigger (`setupMotion` in `src/main.ts`): hero stagger, scrubbing word reveal (`[data-scrub-text]`), card rises (`[data-rise-card]`), and a desktop-only pinned split (`[data-pin-section]`/`[data-pin-target]`). All motion is gated behind `prefers-reduced-motion` via `gsap.matchMedia`.
 - `/docs` is rewritten to `/docs.html` in `vercel.json` and registered as a Rollup input in `vite.config.ts`.
+- Status URLs serve Markdown by default. Discord/Telegram/Slack preview bots get Open Graph HTML from `lib/embed.ts` via `api/convert.ts`; `GET /oembed` is rewritten to `api/oembed.ts`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ curl -sS -G 'https://x.pcstyle.dev/api/convert' \
   --data-urlencode 'url=https://x.com/handle/status/1234567890'
 ```
 
-Browsers that request HTML get a readable page containing the Markdown. Agents can explicitly request `text/markdown`.
+Browsers that request HTML get a readable page containing the Markdown. Agents can explicitly request `text/markdown`. Discord, Telegram, Slack, and other preview bots receive Open Graph embed HTML for the same status URL, including multiple images on Discord, video streams, quote/poll text, and an oEmbed engagement line.
 
 ## Post conversion
 
@@ -63,6 +63,8 @@ curl -sS 'https://x.pcstyle.dev/handle/status/1234567890?format=json'
 ```
 
 JSON conversion responses contain `url`, `markdown`, raw `posts`, `compact`, `warnings`, `postCount`, `source`, `cache`, and `format`. Media in both Markdown and `posts` includes direct video data when the upstream provider exposes it; availability and lifetime of X CDN URLs are controlled by X.
+
+Preview bots hitting `GET /:handle/status/:id` receive embed HTML instead of Markdown. `GET /oembed` is the Discord oEmbed document advertised from that HTML. Explicit `?format=` or `Accept: application/json` / `text/markdown` still wins over user-agent detection.
 
 ## Browse profiles and X
 
@@ -146,7 +148,8 @@ Deploy with Vercel after `bun run build`; `vercel.json` configures `dist`, the A
 ```text
 api/convert.ts     Post conversion handler
 api/browse.ts      Profile, search, followers, and following handler
-lib/               Providers, rendering, pagination, and cache
+api/oembed.ts      Discord oEmbed JSON for chat previews
+lib/               Providers, rendering, pagination, cache, and embeds
 src/               Vite landing page and rendered documentation
 ```
 

--- a/api/convert.ts
+++ b/api/convert.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { ConvertError, acceptPrefersHtml, convertTweet, markdownResponse } from '../lib/converter.js'
 import { embedResponse, isEmbedUserAgent } from '../lib/embed.js'
-import { requestOrigin, setCorsHeaders, wantsJson } from '../lib/http.js'
+import { requestOrigin, setCorsHeaders, wantsJson, wantsMarkdown } from '../lib/http.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCorsHeaders(res)
@@ -16,8 +16,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const userAgent = String(req.headers['user-agent'] ?? '')
   const requestedFormat = param('format')
   const asJson = wantsJson(requestedFormat, accept)
-  const asEmbed = !requestedFormat && !asJson && isEmbedUserAgent(userAgent)
-  const asHtml = !requestedFormat && !asJson && !asEmbed && acceptPrefersHtml(accept)
+  const asMarkdown = wantsMarkdown(requestedFormat, accept)
+  const asEmbed = !requestedFormat && !asJson && !asMarkdown && isEmbedUserAgent(userAgent)
+  const asHtml = !requestedFormat && !asJson && !asMarkdown && !asEmbed && acceptPrefersHtml(accept)
 
   try {
     const result = await convertTweet({

--- a/api/convert.ts
+++ b/api/convert.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { ConvertError, acceptPrefersHtml, convertTweet, markdownResponse } from '../lib/converter.js'
-import { setCorsHeaders, wantsJson } from '../lib/http.js'
+import { embedResponse, isEmbedUserAgent } from '../lib/embed.js'
+import { requestOrigin, setCorsHeaders, wantsJson } from '../lib/http.js'
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   setCorsHeaders(res)
@@ -12,9 +13,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const param = (key: string): string | undefined => (typeof req.query[key] === 'string' ? req.query[key] : undefined)
   const accept = String(req.headers.accept ?? '')
+  const userAgent = String(req.headers['user-agent'] ?? '')
   const requestedFormat = param('format')
   const asJson = wantsJson(requestedFormat, accept)
-  const asHtml = !requestedFormat && !asJson && acceptPrefersHtml(accept)
+  const asEmbed = !requestedFormat && !asJson && isEmbedUserAgent(userAgent)
+  const asHtml = !requestedFormat && !asJson && !asEmbed && acceptPrefersHtml(accept)
 
   try {
     const result = await convertTweet({
@@ -30,7 +33,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       replies: param('replies'),
     })
 
-    const { status, headers, body } = markdownResponse(result, asJson, asHtml)
+    const { status, headers, body } = asEmbed
+      ? embedResponse(result, { origin: requestOrigin(req), userAgent })
+      : markdownResponse(result, asJson, asHtml)
     for (const [key, value] of Object.entries(headers)) {
       res.setHeader(key, value)
     }

--- a/api/oembed.ts
+++ b/api/oembed.ts
@@ -1,0 +1,27 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { oembedResponse } from '../lib/embed.js'
+import { requestOrigin, setCorsHeaders } from '../lib/http.js'
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  setCorsHeaders(res)
+  if (req.method === 'OPTIONS') return res.status(204).end()
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.setHeader('Allow', 'GET, HEAD, OPTIONS')
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const param = (key: string): string | undefined => (typeof req.query[key] === 'string' ? req.query[key] : undefined)
+  const { status, headers, body } = oembedResponse(
+    {
+      text: param('text'),
+      author: param('author'),
+      status: param('status'),
+      provider: param('provider'),
+    },
+    requestOrigin(req),
+  )
+  for (const [key, value] of Object.entries(headers)) {
+    res.setHeader(key, value)
+  }
+  return req.method === 'HEAD' ? res.status(status).end() : res.status(status).send(body)
+}

--- a/api/oembed.ts
+++ b/api/oembed.ts
@@ -13,6 +13,7 @@ export default function handler(req: VercelRequest, res: VercelResponse) {
   const param = (key: string): string | undefined => (typeof req.query[key] === 'string' ? req.query[key] : undefined)
   const { status, headers, body } = oembedResponse(
     {
+      url: param('url'),
       text: param('text'),
       author: param('author'),
       status: param('status'),

--- a/lib/converter.test.ts
+++ b/lib/converter.test.ts
@@ -58,7 +58,7 @@ describe('output selection', () => {
     const result = await convertTweet({ url: validUrl })
     const response = markdownResponse(result)
     expect(response.headers).toMatchObject({
-      Vary: 'Accept',
+      Vary: 'Accept, User-Agent',
       'Cache-Control': 'public, max-age=300',
       'Vercel-CDN-Cache-Control': 'public, s-maxage=300',
     })

--- a/lib/converter.ts
+++ b/lib/converter.ts
@@ -307,7 +307,7 @@ export function markdownResponse(result: ConvertSuccess, asJson = false, asHtml 
   body: string
 } {
   const sharedHeaders: Record<string, string> = {
-    Vary: 'Accept',
+    Vary: 'Accept, User-Agent',
     'X-Converter': 'x-md',
     'X-Source': result.source,
     'X-Post-Count': String(result.postCount),

--- a/lib/embed.test.ts
+++ b/lib/embed.test.ts
@@ -51,11 +51,13 @@ const quoted: FxTweet = {
 }
 
 describe('embed user agents', () => {
-  test('recognizes Discord, Telegram, Slack, and Discord Firefox 92', () => {
+  test('recognizes Discord, Telegram, and Slack preview bots', () => {
     expect(isEmbedUserAgent('Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)')).toBe(true)
     expect(isEmbedUserAgent('TelegramBot (like TwitterBot)')).toBe(true)
     expect(isEmbedUserAgent('Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)')).toBe(true)
-    expect(isEmbedUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:92.0) Gecko/20100101 Firefox/92.0')).toBe(true)
+    expect(isEmbedUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:92.0) Gecko/20100101 Firefox/92.0')).toBe(false)
+    expect(isEmbedUserAgent('Mozilla/5.0 Telegram iOS')).toBe(false)
+    expect(isEmbedUserAgent('Mozilla/5.0 Discord/0.0.300')).toBe(false)
     expect(isEmbedUserAgent('curl/8.7.1')).toBe(false)
     expect(isEmbedUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/131.0.0.0')).toBe(false)
   })
@@ -70,6 +72,7 @@ describe('counts and description', () => {
   test('formats compact social-proof counts', () => {
     expect(formatCount(38)).toBe('38')
     expect(formatCount(78400)).toBe('78.4K')
+    expect(formatCount(999_999)).toBe('1.00M')
     expect(formatCount(1_250_000)).toBe('1.25M')
     expect(socialProof(photoTweet)).toBe('💬 38   🔁 14   ❤️ 469   👁️ 78.4K')
   })
@@ -130,6 +133,47 @@ describe('embed HTML', () => {
     })
     expect(html).toContain('https://mosaic.fxtwitter.com/jpeg/one/two')
     expect(html).not.toContain('https://pbs.twimg.com/two.jpg')
+  })
+
+  test('Telegram uses the quoted mosaic for quote-only multi-photo posts', () => {
+    const html = buildEmbedHtml(
+      {
+        id: '5',
+        text: 'look',
+        author: { name: 'Ada', screen_name: 'ada' },
+        quote: {
+          id: '6',
+          text: 'photos',
+          author: { name: 'Grace', screen_name: 'hopper' },
+          media: {
+            photos: [
+              { type: 'photo', url: 'https://pbs.twimg.com/q1.jpg' },
+              { type: 'photo', url: 'https://pbs.twimg.com/q2.jpg' },
+            ],
+            mosaic: { formats: { jpeg: 'https://mosaic.fxtwitter.com/jpeg/quote' } },
+          },
+        },
+      },
+      { origin: 'https://x.pcstyle.dev', userAgent: 'TelegramBot' },
+    )
+    expect(html).toContain('https://mosaic.fxtwitter.com/jpeg/quote')
+    expect(html).not.toContain('https://pbs.twimg.com/q2.jpg')
+  })
+
+  test('does not emit HLS URLs as og:video', () => {
+    const html = buildEmbedHtml(
+      {
+        id: '8',
+        text: 'stream',
+        author: { name: 'Ada', screen_name: 'ada' },
+        media: {
+          videos: [{ type: 'video', url: 'https://video.twimg.com/clip.m3u8', thumbnail_url: 'https://pbs.twimg.com/thumb.jpg' }],
+        },
+      },
+      { origin: 'https://x.pcstyle.dev', userAgent: 'Discordbot/2.0' },
+    )
+    expect(html).not.toContain('og:video')
+    expect(html).toContain('og:image" content="https://pbs.twimg.com/thumb.jpg"')
   })
 
   test('videos emit player-stream tags and scaled dimensions', () => {

--- a/lib/embed.test.ts
+++ b/lib/embed.test.ts
@@ -123,6 +123,7 @@ describe('embed HTML', () => {
     expect(html).toContain('og:image:alt" content="deal screenshot"')
     expect(html).toContain('type="application/json+oembed"')
     expect(html).toContain('https://x.pcstyle.dev/oembed?')
+    expect(html).toContain('url=https%3A%2F%2Fx.com%2Fnthglsn%2Fstatus%2F2087920734702022870')
     expect(html).toContain('text=%F0%9F%92%AC+38+++%F0%9F%94%81+14+++%E2%9D%A4%EF%B8%8F+469+++%F0%9F%91%81%EF%B8%8F+78.4K')
   })
 
@@ -250,7 +251,12 @@ describe('embed and oEmbed responses', () => {
   test('oembedPayload maps query fields the way Discord reads them', () => {
     expect(
       oembedPayload(
-        { text: '💬 38   🔁 14', author: 'nthglsn', status: '2087920734702022870' },
+        {
+          url: 'https://x.com/nthglsn/status/2087920734702022870',
+          text: '💬 38   🔁 14',
+          author: 'nthglsn',
+          status: '2087920734702022870',
+        },
         'https://x.pcstyle.dev',
       ),
     ).toEqual({
@@ -259,7 +265,7 @@ describe('embed and oEmbed responses', () => {
       provider_name: 'x.md',
       provider_url: 'https://x.pcstyle.dev',
       title: 'Embed',
-      type: 'rich',
+      type: 'link',
       version: '1.0',
     })
   })

--- a/lib/embed.test.ts
+++ b/lib/embed.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from 'vitest'
+import type { ConvertSuccess } from './converter.js'
+import {
+  buildEmbedHtml,
+  embedDescription,
+  embedResponse,
+  formatCount,
+  isEmbedUserAgent,
+  oembedPayload,
+  pickFocalTweet,
+  socialProof,
+  supportsNativeMultiImage,
+} from './embed.js'
+import type { FxTweet } from './fxtwitter.js'
+
+const photoTweet: FxTweet = {
+  id: '2087920734702022870',
+  url: 'https://x.com/nthglsn/status/2087920734702022870',
+  text: '> X offers to sell the @claw handle\n\nWhat should I do?',
+  likes: 469,
+  retweets: 14,
+  replies: 38,
+  views: 78400,
+  lang: 'en',
+  author: {
+    name: 'Nathan',
+    screen_name: 'nthglsn',
+    avatar_url: 'https://pbs.twimg.com/profile.jpg',
+  },
+  media: {
+    photos: [
+      { type: 'photo', url: 'https://pbs.twimg.com/one.jpg', width: 1226, height: 576, alt: 'deal screenshot' },
+      { type: 'photo', url: 'https://pbs.twimg.com/two.jpg', width: 1324, height: 524 },
+    ],
+    mosaic: {
+      type: 'mosaic_photo',
+      formats: { jpeg: 'https://mosaic.fxtwitter.com/jpeg/one/two' },
+    },
+  },
+}
+
+const quoted: FxTweet = {
+  id: '1',
+  text: 'hello <world> & "friends"',
+  author: { name: 'Ada', screen_name: 'ada' },
+  quote: {
+    id: '2',
+    text: 'quoted line',
+    author: { name: 'Grace', screen_name: 'hopper' },
+  },
+}
+
+describe('embed user agents', () => {
+  test('recognizes Discord, Telegram, Slack, and Discord Firefox 92', () => {
+    expect(isEmbedUserAgent('Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)')).toBe(true)
+    expect(isEmbedUserAgent('TelegramBot (like TwitterBot)')).toBe(true)
+    expect(isEmbedUserAgent('Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)')).toBe(true)
+    expect(isEmbedUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:92.0) Gecko/20100101 Firefox/92.0')).toBe(true)
+    expect(isEmbedUserAgent('curl/8.7.1')).toBe(false)
+    expect(isEmbedUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/131.0.0.0')).toBe(false)
+  })
+
+  test('only Discord-like UAs get native multi-image tags', () => {
+    expect(supportsNativeMultiImage('Discordbot/2.0')).toBe(true)
+    expect(supportsNativeMultiImage('TelegramBot')).toBe(false)
+  })
+})
+
+describe('counts and description', () => {
+  test('formats compact social-proof counts', () => {
+    expect(formatCount(38)).toBe('38')
+    expect(formatCount(78400)).toBe('78.4K')
+    expect(formatCount(1_250_000)).toBe('1.25M')
+    expect(socialProof(photoTweet)).toBe('💬 38   🔁 14   ❤️ 469   👁️ 78.4K')
+  })
+
+  test('appends quote attribution and poll bars', () => {
+    const withPoll: FxTweet = {
+      ...quoted,
+      poll: {
+        choices: [
+          { label: 'Yes', percentage: 75 },
+          { label: 'No', percentage: 25 },
+        ],
+        total_votes: 12,
+        time_left_en: 'Final results',
+      },
+    }
+    const text = embedDescription(withPoll)
+    expect(text).toContain('hello <world> & "friends"')
+    expect(text).toContain('Quoting Grace (@hopper)')
+    expect(text).toContain('quoted line')
+    expect(text).toContain('Yes\u2000\u2000(75%)')
+    expect(text).toContain('12 votes · Final results')
+  })
+
+  test('picks the requested post from a conversation', () => {
+    const posts: FxTweet[] = [
+      { id: '1', context: 'parent' },
+      { id: '2', context: 'post' },
+      { id: '3', context: 'reply' },
+    ]
+    expect(pickFocalTweet(posts, '2')?.id).toBe('2')
+    expect(pickFocalTweet(posts)?.id).toBe('2')
+  })
+})
+
+describe('embed HTML', () => {
+  test('Discord gets repeated og:image tags and oEmbed discovery', () => {
+    const html = buildEmbedHtml(photoTweet, {
+      origin: 'https://x.pcstyle.dev',
+      userAgent: 'Discordbot/2.0',
+    })
+    expect(html).toContain('og:title" content="Nathan (@nthglsn)"')
+    expect(html).toContain('og:description" content="&gt; X offers to sell the @claw handle')
+    expect(html).toContain('twitter:card" content="summary_large_image"')
+    expect(html).toContain('og:image" content="https://pbs.twimg.com/one.jpg"')
+    expect(html).toContain('og:image" content="https://pbs.twimg.com/two.jpg"')
+    expect(html).not.toContain('mosaic.fxtwitter.com')
+    expect(html).toContain('og:image:alt" content="deal screenshot"')
+    expect(html).toContain('type="application/json+oembed"')
+    expect(html).toContain('https://x.pcstyle.dev/oembed?')
+    expect(html).toContain('text=%F0%9F%92%AC+38+++%F0%9F%94%81+14+++%E2%9D%A4%EF%B8%8F+469+++%F0%9F%91%81%EF%B8%8F+78.4K')
+  })
+
+  test('Telegram uses the mosaic for multi-photo posts', () => {
+    const html = buildEmbedHtml(photoTweet, {
+      origin: 'https://x.pcstyle.dev',
+      userAgent: 'TelegramBot',
+    })
+    expect(html).toContain('https://mosaic.fxtwitter.com/jpeg/one/two')
+    expect(html).not.toContain('https://pbs.twimg.com/two.jpg')
+  })
+
+  test('videos emit player-stream tags and scaled dimensions', () => {
+    const html = buildEmbedHtml(
+      {
+        id: '9',
+        text: 'watch this',
+        likes: 12,
+        author: { name: 'Ada', screen_name: 'ada' },
+        media: {
+          videos: [
+            {
+              type: 'video',
+              url: 'https://video.twimg.com/low.mp4',
+              thumbnail_url: 'https://pbs.twimg.com/thumb.jpg',
+              width: 3840,
+              height: 2160,
+              variants: [
+                { url: 'https://video.twimg.com/low.mp4', content_type: 'video/mp4', bitrate: 500 },
+                { url: 'https://video.twimg.com/high.mp4', content_type: 'video/mp4', bitrate: 4000 },
+              ],
+            },
+          ],
+        },
+      },
+      { origin: 'https://x.pcstyle.dev', userAgent: 'Discordbot/2.0' },
+    )
+    expect(html).toContain('twitter:card" content="player"')
+    expect(html).toContain('og:video" content="https://video.twimg.com/high.mp4"')
+    expect(html).toContain('og:video:width" content="1920"')
+    expect(html).toContain('og:video:height" content="1080"')
+    expect(html).toContain('og:image" content="https://pbs.twimg.com/thumb.jpg"')
+    expect(html).toContain('provider=')
+  })
+
+  test('text-only posts fall back to the author avatar', () => {
+    const html = buildEmbedHtml(
+      { id: '3', text: 'just words', author: { name: 'Ada', screen_name: 'ada', avatar_url: 'https://pbs.twimg.com/ada.jpg' } },
+      { origin: 'https://x.pcstyle.dev' },
+    )
+    expect(html).toContain('twitter:card" content="summary"')
+    expect(html).toContain('og:image" content="https://pbs.twimg.com/ada.jpg"')
+  })
+
+  test('escapes attribute-breaking characters in titles and descriptions', () => {
+    const html = buildEmbedHtml(quoted, { origin: 'https://x.pcstyle.dev' })
+    expect(html).toContain('hello &lt;world&gt; &amp; &quot;friends&quot;')
+    expect(html).toContain('Quoting Grace (@hopper)')
+  })
+})
+
+describe('embed and oEmbed responses', () => {
+  const result: ConvertSuccess = {
+    body: '# unused',
+    warnings: [],
+    canonicalUrl: 'https://x.com/nthglsn/status/2087920734702022870',
+    format: 'markdown',
+    postCount: 1,
+    source: 'fxtwitter',
+    cache: 'miss',
+    posts: [photoTweet],
+    compact: true,
+  }
+
+  test('embedResponse wraps the focal post as HTML', () => {
+    const response = embedResponse(result, { origin: 'https://x.pcstyle.dev', userAgent: 'Discordbot/2.0' })
+    expect(response.status).toBe(200)
+    expect(response.headers['Content-Type']).toContain('text/html')
+    expect(response.headers.Vary).toBe('Accept, User-Agent')
+    expect(response.headers['X-Embed']).toBe('1')
+    expect(response.body).toContain('Nathan (@nthglsn)')
+  })
+
+  test('oembedPayload maps query fields the way Discord reads them', () => {
+    expect(
+      oembedPayload(
+        { text: '💬 38   🔁 14', author: 'nthglsn', status: '2087920734702022870' },
+        'https://x.pcstyle.dev',
+      ),
+    ).toEqual({
+      author_name: '💬 38   🔁 14',
+      author_url: 'https://x.com/nthglsn/status/2087920734702022870',
+      provider_name: 'x.md',
+      provider_url: 'https://x.pcstyle.dev',
+      title: 'Embed',
+      type: 'rich',
+      version: '1.0',
+    })
+  })
+})

--- a/lib/embed.ts
+++ b/lib/embed.ts
@@ -1,0 +1,338 @@
+import type { ConvertSuccess } from './converter.js'
+import type { FxMedia, FxMediaItem, FxPoll, FxTweet } from './fxtwitter.js'
+
+export const SITE_NAME = 'x.md'
+export const THEME_COLOR = '#146c43'
+
+/** Social preview crawlers that should receive Open Graph HTML. */
+export const EMBED_UA_REGEX =
+  /discordbot|telegrambot|slackbot|slack-img|whatsapp|facebookexternalhit|facebot|linkedinbot|skypeuripreview|vkshare|pinterest|redditbot|embedly|iframely|steamchaturllookup|revoltchat|matrixpreviewbot|discord\/|telegram|firefox\/92/i
+
+export const NATIVE_MULTI_IMAGE_UA_REGEX = /discordbot|matrixpreviewbot/i
+
+export function isEmbedUserAgent(userAgent: string): boolean {
+  return EMBED_UA_REGEX.test(userAgent)
+}
+
+export function supportsNativeMultiImage(userAgent: string): boolean {
+  return NATIVE_MULTI_IMAGE_UA_REGEX.test(userAgent)
+}
+
+export interface EmbedOptions {
+  origin: string
+  userAgent?: string
+}
+
+export interface OEmbedQuery {
+  text?: string | null
+  author?: string | null
+  status?: string | null
+  provider?: string | null
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+export function formatCount(num: number): string {
+  if (num >= 1e6) return `${(num / 1e6).toFixed(2)}M`
+  if (num >= 1e3) return `${(num / 1e3).toFixed(1)}K`
+  return String(num)
+}
+
+export function socialProof(tweet: FxTweet): string | undefined {
+  const parts: string[] = []
+  if ((tweet.replies ?? 0) > 0) parts.push(`💬 ${formatCount(tweet.replies ?? 0)}`)
+  if ((tweet.retweets ?? 0) > 0) parts.push(`🔁 ${formatCount(tweet.retweets ?? 0)}`)
+  if ((tweet.likes ?? 0) > 0) parts.push(`❤️ ${formatCount(tweet.likes ?? 0)}`)
+  if ((tweet.views ?? 0) > 0) parts.push(`👁️ ${formatCount(tweet.views ?? 0)}`)
+  return parts.length ? parts.join('   ') : undefined
+}
+
+function quoteBlock(quote: FxTweet): string {
+  const name = quote.author?.name ?? 'Unknown'
+  const handle = quote.author?.screen_name
+  const header = handle ? `Quoting ${name} (@${handle})` : `Quoting ${name}`
+  const text = quote.text?.trim()
+  return text ? `\n${header}\n\n${text}` : `\n${header}`
+}
+
+function pollBlock(poll: FxPoll, barLength = 32): string {
+  const lines: string[] = ['']
+  for (const choice of poll.choices ?? []) {
+    const pct = choice.percentage ?? 0
+    const bar = '█'.repeat(Math.round((pct / 100) * barLength))
+    const label = choice.label ?? ''
+    lines.push(bar, `${label}\u2000\u2000(${pct}%)`)
+  }
+  const votes = poll.total_votes
+  const timeLeft = poll.time_left_en
+  const footer = [
+    votes != null ? `${votes} ${votes === 1 ? 'vote' : 'votes'}` : undefined,
+    timeLeft,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join(' · ')
+  if (footer) lines.push('', footer)
+  return `\n${lines.join('\n')}`
+}
+
+export function embedDescription(tweet: FxTweet): string {
+  let text = tweet.text ?? ''
+  if (tweet.poll && Array.isArray(tweet.poll.choices)) {
+    text += pollBlock(tweet.poll)
+  }
+  if (tweet.quote) {
+    text += quoteBlock(tweet.quote)
+  }
+  return text
+}
+
+export function pickFocalTweet(posts: FxTweet[], requestedId?: string): FxTweet | undefined {
+  if (requestedId) {
+    const match = posts.find((post) => post.id === requestedId)
+    if (match) return match
+  }
+  return posts.find((post) => post.context === 'post') ?? posts[0]
+}
+
+function bestVideoUrl(item: FxMediaItem): string | undefined {
+  const mp4s = item.variants
+    ?.filter((variant) => variant.url && (variant.content_type === 'video/mp4' || variant.url.includes('.mp4')))
+    .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0))
+  return mp4s?.[0]?.url ?? item.url
+}
+
+function videoDimensions(item: FxMediaItem): { width: number; height: number } {
+  let width = item.width ?? 1280
+  let height = item.height ?? 720
+  if (width > 1920 || height > 1920) {
+    width = Math.round(width / 2)
+    height = Math.round(height / 2)
+  } else if (width < 400 && height < 400) {
+    width *= 2
+    height *= 2
+  }
+  return { width, height }
+}
+
+function firstVideo(media?: FxMedia): FxMediaItem | undefined {
+  return media?.videos?.[0] ?? media?.animated?.[0]
+}
+
+function mosaicUrl(media?: FxMedia): string | undefined {
+  return media?.mosaic?.formats?.jpeg ?? media?.mosaic?.formats?.webp
+}
+
+function photoTags(photo: FxMediaItem): string[] {
+  if (!photo.url) return []
+  const tags = [
+    `<meta property="twitter:image" content="${escapeAttr(photo.url)}">`,
+    `<meta property="og:image" content="${escapeAttr(photo.url)}">`,
+  ]
+  if (photo.width != null && photo.height != null) {
+    const w = String(photo.width)
+    const h = String(photo.height)
+    tags.push(
+      `<meta property="twitter:image:width" content="${w}">`,
+      `<meta property="twitter:image:height" content="${h}">`,
+      `<meta property="og:image:width" content="${w}">`,
+      `<meta property="og:image:height" content="${h}">`,
+    )
+  }
+  const alt = photo.alt ?? photo.altText
+  if (alt) {
+    tags.push(
+      `<meta property="twitter:image:alt" content="${escapeAttr(alt)}">`,
+      `<meta property="og:image:alt" content="${escapeAttr(alt)}">`,
+    )
+  }
+  return tags
+}
+
+function videoTags(video: FxMediaItem): string[] {
+  const url = bestVideoUrl(video)
+  if (!url) return []
+  const { width, height } = videoDimensions(video)
+  const mime = video.format?.includes('/') ? video.format : 'video/mp4'
+  const thumb = video.thumbnail_url
+  const tags = [
+    `<meta property="twitter:player:width" content="${width}">`,
+    `<meta property="twitter:player:height" content="${height}">`,
+    `<meta property="twitter:player:stream" content="${escapeAttr(url)}">`,
+    `<meta property="twitter:player:stream:content_type" content="${escapeAttr(mime)}">`,
+    `<meta property="og:video" content="${escapeAttr(url)}">`,
+    `<meta property="og:video:secure_url" content="${escapeAttr(url)}">`,
+    `<meta property="og:video:type" content="${escapeAttr(mime)}">`,
+    `<meta property="og:video:width" content="${width}">`,
+    `<meta property="og:video:height" content="${height}">`,
+  ]
+  if (thumb) {
+    tags.push(`<meta property="og:image" content="${escapeAttr(thumb)}">`)
+    tags.push('<meta property="twitter:image" content="0">')
+  }
+  return tags
+}
+
+interface MediaPlan {
+  card: 'summary' | 'summary_large_image' | 'player'
+  tags: string[]
+}
+
+function mediaPlan(tweet: FxTweet, multiImage: boolean): MediaPlan {
+  const own = tweet.media
+  const quoted = tweet.quote?.media
+  const video = firstVideo(own) ?? firstVideo(quoted)
+  if (video && bestVideoUrl(video)) {
+    return { card: 'player', tags: videoTags(video) }
+  }
+
+  const photos = own?.photos?.filter((photo) => photo.url) ?? []
+  const quotedPhotos = quoted?.photos?.filter((photo) => photo.url) ?? []
+  const mosaic = mosaicUrl(own) ?? mosaicUrl(quoted)
+
+  if (photos.length > 1 && multiImage) {
+    return { card: 'summary_large_image', tags: photos.flatMap(photoTags) }
+  }
+  if (mosaic && photos.length > 1) {
+    return {
+      card: 'summary_large_image',
+      tags: [
+        `<meta property="twitter:image" content="${escapeAttr(mosaic)}">`,
+        `<meta property="og:image" content="${escapeAttr(mosaic)}">`,
+      ],
+    }
+  }
+  if (photos[0]) {
+    return { card: 'summary_large_image', tags: photoTags(photos[0]) }
+  }
+  if (quotedPhotos.length > 1 && multiImage) {
+    return { card: 'summary_large_image', tags: quotedPhotos.flatMap(photoTags) }
+  }
+  if (quotedPhotos[0]) {
+    return { card: 'summary_large_image', tags: photoTags(quotedPhotos[0]) }
+  }
+
+  const avatar = tweet.author?.avatar_url
+  if (avatar) {
+    return {
+      card: 'summary',
+      tags: [
+        `<meta property="og:image" content="${escapeAttr(avatar)}">`,
+        '<meta property="twitter:image" content="0">',
+        `<link rel="apple-touch-icon" href="${escapeAttr(avatar)}">`,
+      ],
+    }
+  }
+  return { card: 'summary', tags: [] }
+}
+
+export function buildEmbedHtml(tweet: FxTweet, options: EmbedOptions): string {
+  const handle = tweet.author?.screen_name ?? 'i'
+  const name = tweet.author?.name ?? handle
+  const id = tweet.id ?? '0'
+  const canonical = tweet.url ?? `https://x.com/${handle}/status/${id}`
+  const title = `${name} (@${handle})`
+  const description = embedDescription(tweet)
+  const proof = socialProof(tweet) ?? 'Embed'
+  const multiImage = supportsNativeMultiImage(options.userAgent ?? '')
+  const media = mediaPlan(tweet, multiImage)
+  const oembed = new URL('/oembed', options.origin)
+  oembed.searchParams.set('text', proof.slice(0, 255))
+  oembed.searchParams.set('status', id)
+  oembed.searchParams.set('author', handle)
+  if (media.card === 'player' && proof !== 'Embed') {
+    oembed.searchParams.set('provider', proof)
+  }
+
+  const tags = [
+    `<link rel="canonical" href="${escapeAttr(canonical)}">`,
+    `<meta property="og:url" content="${escapeAttr(canonical)}">`,
+    `<meta property="og:title" content="${escapeAttr(title)}">`,
+    `<meta property="og:description" content="${escapeAttr(description)}">`,
+    `<meta property="og:site_name" content="${SITE_NAME}">`,
+    `<meta property="theme-color" content="${THEME_COLOR}">`,
+    `<meta property="twitter:card" content="${media.card}">`,
+    `<meta property="twitter:title" content="${escapeAttr(title)}">`,
+    `<meta property="twitter:site" content="@${escapeAttr(handle)}">`,
+    `<meta property="twitter:creator" content="@${escapeAttr(handle)}">`,
+    ...media.tags,
+    `<link rel="alternate" type="application/json+oembed" href="${escapeAttr(oembed.toString())}" title="${escapeAttr(name)}">`,
+  ]
+
+  return `<!doctype html>
+<html lang="${escapeAttr(tweet.lang ?? 'en')}">
+<head>
+${tags.join('\n')}
+</head>
+<body></body>
+</html>`
+}
+
+export function embedResponse(
+  result: ConvertSuccess,
+  options: EmbedOptions,
+): { status: number; headers: Record<string, string>; body: string } {
+  const requestedId = result.canonicalUrl.match(/\/status\/(\d+)/)?.[1]
+  const tweet = pickFocalTweet(result.posts, requestedId)
+  if (!tweet) {
+    return {
+      status: 404,
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({ error: 'Post not found or unavailable.', code: 'not_found' }),
+    }
+  }
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'text/html; charset=utf-8',
+    Vary: 'Accept, User-Agent',
+    'X-Converter': 'x-md',
+    'X-Embed': '1',
+    'X-Source': result.source,
+    'X-Post-Count': String(result.postCount),
+    'X-Warnings': String(result.warnings.length),
+    'X-Cache': result.cache.toUpperCase(),
+  }
+  if (result.cache !== 'bypass') {
+    headers['Cache-Control'] = 'public, max-age=0, must-revalidate'
+    const ttl = Number.parseInt(process.env.CACHE_TTL_SECONDS ?? '3600', 10)
+    const seconds = Number.isFinite(ttl) && ttl > 0 ? ttl : 3600
+    headers['Vercel-CDN-Cache-Control'] = `public, s-maxage=${seconds}, stale-while-revalidate=86400`
+  }
+
+  return { status: 200, headers, body: buildEmbedHtml(tweet, options) }
+}
+
+export function oembedPayload(query: OEmbedQuery, origin: string): Record<string, string> {
+  const author = query.author || 'i'
+  const status = query.status || '0'
+  const statusUrl = `https://x.com/${encodeURIComponent(author)}/status/${status}`
+  return {
+    author_name: query.text || 'Embed',
+    author_url: statusUrl,
+    provider_name: query.provider || SITE_NAME,
+    provider_url: query.provider ? statusUrl : origin,
+    title: 'Embed',
+    type: 'rich',
+    version: '1.0',
+  }
+}
+
+export function oembedResponse(
+  query: OEmbedQuery,
+  origin: string,
+): { status: number; headers: Record<string, string>; body: string } {
+  return {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=3600',
+    },
+    body: JSON.stringify(oembedPayload(query, origin)),
+  }
+}

--- a/lib/embed.ts
+++ b/lib/embed.ts
@@ -6,7 +6,7 @@ export const THEME_COLOR = '#146c43'
 
 /** Social preview crawlers that should receive Open Graph HTML. */
 export const EMBED_UA_REGEX =
-  /discordbot|telegrambot|slackbot|slack-img|whatsapp|facebookexternalhit|facebot|linkedinbot|skypeuripreview|vkshare|pinterest|redditbot|embedly|iframely|steamchaturllookup|revoltchat|matrixpreviewbot|discord\/|telegram|firefox\/92/i
+  /discordbot|telegrambot|slackbot|slack-img|whatsapp|facebookexternalhit|facebot|linkedinbot|skypeuripreview|vkshare|pinterest|redditbot|embedly|iframely|steamchaturllookup|revoltchat|matrixpreviewbot/i
 
 export const NATIVE_MULTI_IMAGE_UA_REGEX = /discordbot|matrixpreviewbot/i
 
@@ -40,6 +40,7 @@ function escapeAttr(value: string): string {
 
 export function formatCount(num: number): string {
   if (num >= 1e6) return `${(num / 1e6).toFixed(2)}M`
+  if (num >= 995_000) return '1.00M'
   if (num >= 1e3) return `${(num / 1e3).toFixed(1)}K`
   return String(num)
 }
@@ -100,11 +101,18 @@ export function pickFocalTweet(posts: FxTweet[], requestedId?: string): FxTweet 
   return posts.find((post) => post.context === 'post') ?? posts[0]
 }
 
+function isPlayableMp4(url: string, contentType?: string): boolean {
+  if (contentType === 'video/mp4') return true
+  return /\.mp4(?:$|[?#])/i.test(url)
+}
+
 function bestVideoUrl(item: FxMediaItem): string | undefined {
   const mp4s = item.variants
-    ?.filter((variant) => variant.url && (variant.content_type === 'video/mp4' || variant.url.includes('.mp4')))
+    ?.filter((variant) => variant.url && isPlayableMp4(variant.url, variant.content_type))
     .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0))
-  return mp4s?.[0]?.url ?? item.url
+  if (mp4s?.[0]?.url) return mp4s[0].url
+  if (item.url && isPlayableMp4(item.url, item.format)) return item.url
+  return undefined
 }
 
 function videoDimensions(item: FxMediaItem): { width: number; height: number } {
@@ -183,27 +191,42 @@ interface MediaPlan {
   tags: string[]
 }
 
+function stillImagePlan(item: FxMediaItem | undefined): MediaPlan | undefined {
+  const url = item?.thumbnail_url ?? item?.url
+  if (!url || /\.m3u8(?:$|[?#])/i.test(url)) return undefined
+  return {
+    card: 'summary_large_image',
+    tags: [
+      `<meta property="twitter:image" content="${escapeAttr(url)}">`,
+      `<meta property="og:image" content="${escapeAttr(url)}">`,
+    ],
+  }
+}
+
 function mediaPlan(tweet: FxTweet, multiImage: boolean): MediaPlan {
   const own = tweet.media
   const quoted = tweet.quote?.media
   const video = firstVideo(own) ?? firstVideo(quoted)
-  if (video && bestVideoUrl(video)) {
-    return { card: 'player', tags: videoTags(video) }
+  if (video) {
+    if (bestVideoUrl(video)) return { card: 'player', tags: videoTags(video) }
+    const still = stillImagePlan(video)
+    if (still) return still
   }
 
   const photos = own?.photos?.filter((photo) => photo.url) ?? []
   const quotedPhotos = quoted?.photos?.filter((photo) => photo.url) ?? []
-  const mosaic = mosaicUrl(own) ?? mosaicUrl(quoted)
+  const ownMosaic = mosaicUrl(own)
+  const quotedMosaic = mosaicUrl(quoted)
 
   if (photos.length > 1 && multiImage) {
     return { card: 'summary_large_image', tags: photos.flatMap(photoTags) }
   }
-  if (mosaic && photos.length > 1) {
+  if (ownMosaic && photos.length > 1) {
     return {
       card: 'summary_large_image',
       tags: [
-        `<meta property="twitter:image" content="${escapeAttr(mosaic)}">`,
-        `<meta property="og:image" content="${escapeAttr(mosaic)}">`,
+        `<meta property="twitter:image" content="${escapeAttr(ownMosaic)}">`,
+        `<meta property="og:image" content="${escapeAttr(ownMosaic)}">`,
       ],
     }
   }
@@ -212,6 +235,15 @@ function mediaPlan(tweet: FxTweet, multiImage: boolean): MediaPlan {
   }
   if (quotedPhotos.length > 1 && multiImage) {
     return { card: 'summary_large_image', tags: quotedPhotos.flatMap(photoTags) }
+  }
+  if (quotedMosaic && quotedPhotos.length > 1) {
+    return {
+      card: 'summary_large_image',
+      tags: [
+        `<meta property="twitter:image" content="${escapeAttr(quotedMosaic)}">`,
+        `<meta property="og:image" content="${escapeAttr(quotedMosaic)}">`,
+      ],
+    }
   }
   if (quotedPhotos[0]) {
     return { card: 'summary_large_image', tags: photoTags(quotedPhotos[0]) }
@@ -255,7 +287,7 @@ export function buildEmbedHtml(tweet: FxTweet, options: EmbedOptions): string {
     `<meta property="og:title" content="${escapeAttr(title)}">`,
     `<meta property="og:description" content="${escapeAttr(description)}">`,
     `<meta property="og:site_name" content="${SITE_NAME}">`,
-    `<meta property="theme-color" content="${THEME_COLOR}">`,
+    `<meta name="theme-color" content="${THEME_COLOR}">`,
     `<meta property="twitter:card" content="${media.card}">`,
     `<meta property="twitter:title" content="${escapeAttr(title)}">`,
     `<meta property="twitter:site" content="@${escapeAttr(handle)}">`,

--- a/lib/embed.ts
+++ b/lib/embed.ts
@@ -24,6 +24,7 @@ export interface EmbedOptions {
 }
 
 export interface OEmbedQuery {
+  url?: string | null
   text?: string | null
   author?: string | null
   status?: string | null
@@ -274,6 +275,7 @@ export function buildEmbedHtml(tweet: FxTweet, options: EmbedOptions): string {
   const multiImage = supportsNativeMultiImage(options.userAgent ?? '')
   const media = mediaPlan(tweet, multiImage)
   const oembed = new URL('/oembed', options.origin)
+  oembed.searchParams.set('url', canonical)
   oembed.searchParams.set('text', proof.slice(0, 255))
   oembed.searchParams.set('status', id)
   oembed.searchParams.set('author', handle)
@@ -340,17 +342,33 @@ export function embedResponse(
 }
 
 export function oembedPayload(query: OEmbedQuery, origin: string): Record<string, string> {
-  const author = query.author || 'i'
-  const status = query.status || '0'
-  const statusUrl = `https://x.com/${encodeURIComponent(author)}/status/${status}`
+  const fromUrl = query.url ? parseStatusUrlSafe(query.url) : undefined
+  const author = fromUrl?.handle || query.author || 'i'
+  const status = fromUrl?.id || query.status || '0'
+  const statusUrl = fromUrl?.canonicalUrl ?? `https://x.com/${encodeURIComponent(author)}/status/${status}`
   return {
     author_name: query.text || 'Embed',
     author_url: statusUrl,
     provider_name: query.provider || SITE_NAME,
     provider_url: query.provider ? statusUrl : origin,
     title: 'Embed',
-    type: 'rich',
+    type: 'link',
     version: '1.0',
+  }
+}
+
+function parseStatusUrlSafe(raw: string): { handle: string; id: string; canonicalUrl: string } | undefined {
+  try {
+    const parsed = new URL(raw)
+    const match = /^\/([^/?#]+)\/status\/(\d+)\/?$/.exec(parsed.pathname)
+    if (!match) return undefined
+    return {
+      handle: match[1],
+      id: match[2],
+      canonicalUrl: `https://x.com/${match[1]}/status/${match[2]}`,
+    }
+  } catch {
+    return undefined
   }
 }
 

--- a/lib/fxtwitter.ts
+++ b/lib/fxtwitter.ts
@@ -34,6 +34,8 @@ export interface FxMediaItem {
   duration_ms?: number
   format?: string
   bitrate?: number
+  alt?: string
+  altText?: string
   variants?: Array<{
     url: string
     content_type?: string
@@ -47,12 +49,31 @@ export interface FxMediaItem {
   }>
 }
 
+export interface FxMosaic {
+  type?: string
+  photos?: FxMediaItem[]
+  formats?: { jpeg?: string; webp?: string }
+}
+
 export interface FxMedia {
   photos?: FxMediaItem[]
   videos?: FxMediaItem[]
   animated?: FxMediaItem[]
-  mosaic?: { photos?: FxMediaItem[] }
+  mosaic?: FxMosaic
   all?: FxMediaItem[]
+}
+
+export interface FxPollChoice {
+  label?: string
+  count?: number
+  percentage?: number
+}
+
+export interface FxPoll {
+  choices?: FxPollChoice[]
+  total_votes?: number
+  time_left_en?: string
+  ends_at?: string
 }
 
 export interface FxArticleBlock {
@@ -105,7 +126,7 @@ export interface FxTweet {
   quote?: FxTweet
   reposted_by?: FxAuthor | null
   article?: FxArticle
-  poll?: unknown
+  poll?: FxPoll
   community_note?: unknown
   /** How this post relates to the status requested by the caller. */
   context?: 'parent' | 'post' | 'thread' | 'reply'
@@ -152,6 +173,7 @@ function normalizeMediaItem(item: FxMediaItem): FxMediaItem {
   }))
   return {
     ...item,
+    alt: item.alt ?? item.altText,
     duration_ms: item.duration_ms ?? (item.duration != null ? item.duration * 1000 : undefined),
     variants: item.variants ?? formatVariants,
   }

--- a/lib/http.test.ts
+++ b/lib/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { requestOrigin, wantsJson } from './http.js'
+import { requestOrigin, wantsJson, wantsMarkdown } from './http.js'
 
 describe('requestOrigin', () => {
   test('prefers forwarded host and proto', () => {
@@ -12,6 +12,18 @@ describe('requestOrigin', () => {
 
   test('falls back to the hosted origin', () => {
     expect(requestOrigin({ headers: {} })).toBe('https://x.pcstyle.dev')
+  })
+})
+
+describe('wantsMarkdown', () => {
+  test('gives an explicit format precedence over Accept', () => {
+    expect(wantsMarkdown('json', 'text/markdown')).toBe(false)
+    expect(wantsMarkdown('markdown', 'application/json')).toBe(true)
+  })
+
+  test('uses Accept when no format is explicit', () => {
+    expect(wantsMarkdown(undefined, 'text/markdown')).toBe(true)
+    expect(wantsMarkdown(undefined, 'text/html')).toBe(false)
   })
 })
 

--- a/lib/http.test.ts
+++ b/lib/http.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, test } from 'vitest'
-import { wantsJson } from './http.js'
+import { requestOrigin, wantsJson } from './http.js'
+
+describe('requestOrigin', () => {
+  test('prefers forwarded host and proto', () => {
+    expect(
+      requestOrigin({
+        headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'x.pcstyle.dev', host: 'localhost:3000' },
+      }),
+    ).toBe('https://x.pcstyle.dev')
+  })
+
+  test('falls back to the hosted origin', () => {
+    expect(requestOrigin({ headers: {} })).toBe('https://x.pcstyle.dev')
+  })
+})
 
 describe('wantsJson', () => {
   test('gives an explicit format precedence over Accept', () => {

--- a/lib/http.test.ts
+++ b/lib/http.test.ts
@@ -2,16 +2,31 @@ import { describe, expect, test } from 'vitest'
 import { requestOrigin, wantsJson, wantsMarkdown } from './http.js'
 
 describe('requestOrigin', () => {
-  test('prefers forwarded host and proto', () => {
+  test('uses the request host for known public and local hosts', () => {
     expect(
       requestOrigin({
-        headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'x.pcstyle.dev', host: 'localhost:3000' },
+        headers: { 'x-forwarded-proto': 'https', host: 'x.pcstyle.dev' },
+      }),
+    ).toBe('https://x.pcstyle.dev')
+    expect(
+      requestOrigin({
+        headers: { host: 'localhost:5173' },
+        protocol: 'http',
+      }),
+    ).toBe('http://localhost:5173')
+  })
+
+  test('ignores a forged forwarded host', () => {
+    expect(
+      requestOrigin({
+        headers: { 'x-forwarded-host': 'evil.example', host: 'x.pcstyle.dev' },
       }),
     ).toBe('https://x.pcstyle.dev')
   })
 
   test('falls back to the hosted origin', () => {
     expect(requestOrigin({ headers: {} })).toBe('https://x.pcstyle.dev')
+    expect(requestOrigin({ headers: { host: 'evil.example' } })).toBe('https://x.pcstyle.dev')
   })
 })
 

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -31,3 +31,8 @@ export function wantsJson(format: string | null | undefined, accept: string): bo
   if (format) return format === 'json'
   return accept.includes('application/json')
 }
+
+export function wantsMarkdown(format: string | null | undefined, accept: string): boolean {
+  if (format) return format === 'markdown' || format === 'obsidian'
+  return accept.includes('text/markdown')
+}

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -3,6 +3,24 @@ export interface HeaderWriter {
   setHeader(name: string, value: string): void
 }
 
+export interface OriginRequest {
+  headers: {
+    host?: string | string[]
+    'x-forwarded-proto'?: string | string[]
+    'x-forwarded-host'?: string | string[]
+  }
+}
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export function requestOrigin(req: OriginRequest, fallback = 'https://x.pcstyle.dev'): string {
+  const proto = headerValue(req.headers['x-forwarded-proto']) ?? 'https'
+  const host = headerValue(req.headers['x-forwarded-host']) ?? headerValue(req.headers.host)
+  return host ? `${proto}://${host}` : fallback
+}
+
 export function setCorsHeaders(res: HeaderWriter, methods = 'GET, HEAD, OPTIONS'): void {
   res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', methods)

--- a/lib/http.ts
+++ b/lib/http.ts
@@ -9,16 +9,38 @@ export interface OriginRequest {
     'x-forwarded-proto'?: string | string[]
     'x-forwarded-host'?: string | string[]
   }
+  protocol?: string
+  socket?: unknown
 }
+
+const PUBLIC_EMBED_HOSTS = new Set(['x.pcstyle.dev', 'x-md.vercel.app'])
 
 function headerValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value
 }
 
+function hostnameOf(host: string | undefined): string | undefined {
+  if (!host) return undefined
+  return host.split(',')[0]?.trim().replace(/:\d+$/, '') || undefined
+}
+
+function requestProtocol(req: OriginRequest): 'http' | 'https' {
+  const forwarded = headerValue(req.headers['x-forwarded-proto'])?.split(',')[0]?.trim().toLowerCase()
+  if (forwarded === 'http' || forwarded === 'https') return forwarded
+  if (req.protocol === 'http:' || req.protocol === 'http') return 'http'
+  if (req.socket && typeof req.socket === 'object' && 'encrypted' in req.socket && req.socket.encrypted) {
+    return 'https'
+  }
+  return 'https'
+}
+
 export function requestOrigin(req: OriginRequest, fallback = 'https://x.pcstyle.dev'): string {
-  const proto = headerValue(req.headers['x-forwarded-proto']) ?? 'https'
-  const host = headerValue(req.headers['x-forwarded-host']) ?? headerValue(req.headers.host)
-  return host ? `${proto}://${host}` : fallback
+  const hostHeader = headerValue(req.headers.host)
+  const hostname = hostnameOf(hostHeader)
+  if (hostname && (PUBLIC_EMBED_HOSTS.has(hostname) || hostname === 'localhost' || hostname === '127.0.0.1')) {
+    return `${requestProtocol(req)}://${hostHeader}`
+  }
+  return fallback
 }
 
 export function setCorsHeaders(res: HeaderWriter, methods = 'GET, HEAD, OPTIONS'): void {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,6 +16,8 @@ Source: https://github.com/pc-style/x-md
 
 Browse routes accept `cursor`, `page`, `limit`, `full=true`, and `format=json`. Post routes also support thread, conversation context, reply ordering, and Obsidian output; see the documentation for exact query parameters.
 
+Discord, Telegram, Slack, and other preview bots receive Open Graph embed HTML on status URLs instead of Markdown. `GET /oembed` is the advertised oEmbed document. Explicit `?format=` or `Accept` still wins.
+
 ## Scope
 
 x.md only reads public content and does not post, follow, like, or authenticate as an X user. X Lists are not supported.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Allow: /
+Allow: /oembed
 Disallow: /api/
 
 Sitemap: https://x.pcstyle.dev/sitemap.xml

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -69,7 +69,7 @@ curl -sS -G "https://x.pcstyle.dev/api/convert" \\
           <h3 class="mt-8 text-[19px] font-semibold text-ink">Chat embeds</h3>
           <p class="mt-3 text-[16px] leading-relaxed text-ink-3">Paste the same <code class="code-chip">x.pcstyle.dev</code> status URL into Discord, Telegram, or Slack. Preview bots receive Open Graph HTML: author title, post text, quote/poll details, multiple images on Discord, video streams, and an oEmbed engagement line. Agents and <code class="code-chip">curl</code> still get Markdown unless they send a preview-bot user agent. Force Markdown or JSON with <code class="code-chip">Accept</code> or <code class="code-chip">?format=</code>.</p>
           <pre class="code-block mt-6">curl -sS -A "Discordbot/2.0" "${example}"
-curl -sS "https://x.pcstyle.dev/oembed?text=💬%2038&amp;author=nthglsn&amp;status=2087920734702022870"</pre>
+curl -sS -G "https://x.pcstyle.dev/oembed" --data-urlencode "url=https://x.com/nthglsn/status/2087920734702022870"</pre>
         </article>
 
         <article id="browse" class="docs-article">

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -34,7 +34,7 @@ app.innerHTML = `
         <article id="start" class="docs-article">
           <p class="eyebrow eyebrow-muted mb-3">Hosted API</p>
           <h2 class="text-[24px] leading-tight font-semibold text-ink">Replace the host</h2>
-          <p class="mt-3 text-[16px] leading-relaxed text-ink-3">Keep a public status path and replace <code class="code-chip">x.com</code> with <code class="code-chip">x.pcstyle.dev</code>. Markdown is compact by default, and every returned post and reply includes its X source URL.</p>
+          <p class="mt-3 text-[16px] leading-relaxed text-ink-3">Keep a public status path and replace <code class="code-chip">x.com</code> with <code class="code-chip">x.pcstyle.dev</code>. Markdown is compact by default, and every returned post and reply includes its X source URL. Discord, Telegram, and Slack get Open Graph embeds instead of the Markdown page.</p>
           <pre class="code-block mt-6">https://x.com/trq212/status/2052809885763747935
         ↓
 ${example}
@@ -66,6 +66,10 @@ curl -sS "${example}?context=thread&amp;thread=20"
 curl -sS -G "https://x.pcstyle.dev/api/convert" \\
   --data-urlencode "url=https://x.com/trq212/status/2052809885763747935"</pre>
           <p class="mt-4 text-[14px] leading-relaxed text-ink-4"><code class="code-chip">thread=off</code> returns only the requested post. Obsidian output is expanded regardless of <code class="code-chip">full</code>. Direct X CDN media URLs can expire or change.</p>
+          <h3 class="mt-8 text-[19px] font-semibold text-ink">Chat embeds</h3>
+          <p class="mt-3 text-[16px] leading-relaxed text-ink-3">Paste the same <code class="code-chip">x.pcstyle.dev</code> status URL into Discord, Telegram, or Slack. Preview bots receive Open Graph HTML: author title, post text, quote/poll details, multiple images on Discord, video streams, and an oEmbed engagement line. Agents and <code class="code-chip">curl</code> still get Markdown unless they send a preview-bot user agent. Force Markdown or JSON with <code class="code-chip">Accept</code> or <code class="code-chip">?format=</code>.</p>
+          <pre class="code-block mt-6">curl -sS -A "Discordbot/2.0" "${example}"
+curl -sS "https://x.pcstyle.dev/oembed?text=💬%2038&amp;author=nthglsn&amp;status=2087920734702022870"</pre>
         </article>
 
         <article id="browse" class="docs-article">

--- a/src/vite-api-plugin.ts
+++ b/src/vite-api-plugin.ts
@@ -3,13 +3,14 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Plugin } from 'vite'
 import { browse, browseResponse, type BrowseResource } from '../lib/browse'
 import { ConvertError as BrowseError } from '../lib/errors'
-import { setCorsHeaders, wantsJson } from '../lib/http'
+import { requestOrigin, setCorsHeaders, wantsJson } from '../lib/http'
 import {
   acceptPrefersHtml,
   ConvertError,
   convertTweet,
   markdownResponse,
 } from '../lib/converter'
+import { embedResponse, isEmbedUserAgent, oembedResponse } from '../lib/embed'
 
 const HANDLE = '[A-Za-z0-9_]{1,15}'
 
@@ -50,9 +51,11 @@ async function handleConvert(
   if (guardMethod(req, res)) return true
 
   const accept = String(req.headers.accept ?? '')
+  const userAgent = String(req.headers['user-agent'] ?? '')
   const requestedFormat = url.searchParams.get('format')
   const asJson = wantsJson(requestedFormat, accept)
-  const asHtml = !requestedFormat && !asJson && acceptPrefersHtml(accept)
+  const asEmbed = !requestedFormat && !asJson && isEmbedUserAgent(userAgent)
+  const asHtml = !requestedFormat && !asJson && !asEmbed && acceptPrefersHtml(accept)
 
   try {
     const result = await convertTweet({
@@ -68,7 +71,9 @@ async function handleConvert(
       replies: url.searchParams.get('replies'),
     })
 
-    const { status, headers, body } = markdownResponse(result, asJson, asHtml)
+    const { status, headers, body } = asEmbed
+      ? embedResponse(result, { origin: requestOrigin(req), userAgent })
+      : markdownResponse(result, asJson, asHtml)
     res.statusCode = status
     for (const [key, value] of Object.entries(headers)) {
       res.setHeader(key, value)
@@ -90,6 +95,27 @@ async function handleConvert(
   return true
 }
 
+async function handleOembed(url: URL, req: IncomingMessage, res: ServerResponse): Promise<boolean> {
+  if (url.pathname.replace(/\/$/, '') !== '/oembed') return false
+  setCorsHeaders(res)
+  if (guardMethod(req, res)) return true
+  const { status, headers, body } = oembedResponse(
+    {
+      text: url.searchParams.get('text'),
+      author: url.searchParams.get('author'),
+      status: url.searchParams.get('status'),
+      provider: url.searchParams.get('provider'),
+    },
+    requestOrigin(req),
+  )
+  res.statusCode = status
+  for (const [key, value] of Object.entries(headers)) {
+    res.setHeader(key, value)
+  }
+  res.end(req.method === 'HEAD' ? undefined : body)
+  return true
+}
+
 async function handleBrowse(url: URL, req: IncomingMessage, res: ServerResponse): Promise<boolean> {
   const path = url.pathname.replace(/\/$/, '') || '/'
   let resource: BrowseResource | undefined
@@ -98,7 +124,7 @@ async function handleBrowse(url: URL, req: IncomingMessage, res: ServerResponse)
   else if (path === '/search') resource = 'search'
   else {
     const match = path.match(new RegExp(`^\/(${HANDLE})(?:\/(followers|following))?$`))
-    if (!match || ['api', 'docs', 'search'].includes(match[1] ?? '')) return false
+    if (!match || ['api', 'docs', 'search', 'oembed'].includes(match[1] ?? '')) return false
     handle = match[1]
     resource = (match[2] as BrowseResource | undefined) ?? 'profile'
   }
@@ -131,7 +157,10 @@ function installConvertMiddleware(middlewares: Connect.Server) {
           return
         }
         const url = new URL(req.url, 'http://localhost')
-        const handled = await handleConvert(url, req, res) || await handleBrowse(url, req, res)
+        const handled =
+          (await handleOembed(url, req, res)) ||
+          (await handleConvert(url, req, res)) ||
+          (await handleBrowse(url, req, res))
         if (!handled) next()
       } catch (error) {
         next(error as Error)

--- a/src/vite-api-plugin.ts
+++ b/src/vite-api-plugin.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Plugin } from 'vite'
 import { browse, browseResponse, type BrowseResource } from '../lib/browse'
 import { ConvertError as BrowseError } from '../lib/errors'
-import { requestOrigin, setCorsHeaders, wantsJson } from '../lib/http'
+import { requestOrigin, setCorsHeaders, wantsJson, wantsMarkdown } from '../lib/http'
 import {
   acceptPrefersHtml,
   ConvertError,
@@ -54,8 +54,9 @@ async function handleConvert(
   const userAgent = String(req.headers['user-agent'] ?? '')
   const requestedFormat = url.searchParams.get('format')
   const asJson = wantsJson(requestedFormat, accept)
-  const asEmbed = !requestedFormat && !asJson && isEmbedUserAgent(userAgent)
-  const asHtml = !requestedFormat && !asJson && !asEmbed && acceptPrefersHtml(accept)
+  const asMarkdown = wantsMarkdown(requestedFormat, accept)
+  const asEmbed = !requestedFormat && !asJson && !asMarkdown && isEmbedUserAgent(userAgent)
+  const asHtml = !requestedFormat && !asJson && !asMarkdown && !asEmbed && acceptPrefersHtml(accept)
 
   try {
     const result = await convertTweet({
@@ -101,6 +102,7 @@ async function handleOembed(url: URL, req: IncomingMessage, res: ServerResponse)
   if (guardMethod(req, res)) return true
   const { status, headers, body } = oembedResponse(
     {
+      url: url.searchParams.get('url'),
       text: url.searchParams.get('text'),
       author: url.searchParams.get('author'),
       status: url.searchParams.get('status'),

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,10 @@
       "destination": "/api/convert?handle=:handle&id=:id"
     },
     {
+      "source": "/oembed",
+      "destination": "/api/oembed"
+    },
+    {
       "source": "/search",
       "destination": "/api/browse?resource=search"
     },


### PR DESCRIPTION
## Problem

Pasting an `x.pcstyle.dev` status URL into Discord, Telegram, or Slack showed the site's generic Markdown/HTML page instead of a tweet card. FixupX works because preview bots get Open Graph HTML; this API only content-negotiated Markdown, JSON, or a Markdown HTML wrapper.

## Change

Status URLs now branch on user agent after format/Accept still win:

- Discord, Telegram, Slack, and other preview bots get Open Graph HTML for the requested post
- Discord gets repeated `og:image` tags plus an oEmbed engagement line
- Telegram gets a mosaic for multi-photo posts
- Videos use the highest-bitrate MP4 as `og:video` / `twitter:player:stream`
- Quotes and polls are appended to `og:description`
- `GET /oembed` serves the advertised oEmbed JSON

`curl`, agents, and `?format=` / `Accept` still return Markdown or JSON.

## Validation

`bun run test` (103 tests) and `tsc --noEmit` passed locally.

After merge, paste `https://x.pcstyle.dev/nthglsn/status/2087920734702022870` in Discord. If Discord caches a stale preview, append `?` once.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve Open Graph HTML to Discord, Telegram, and Slack preview bots on status URLs so chat cards render correctly. Previously, bots got the Markdown/HTML wrapper; now they get OG HTML with multi-image (Discord-only), Telegram mosaics, MP4 video streams, and quote/poll details. Explicit `Accept` or `?format=` for Markdown/JSON still wins over bot detection.

- Add `lib/embed.ts` for bot UA detection (bot-only tokens), Discord-only native multi-image, media selection, OG tag generation, count formatting, and spec-shaped oEmbed payloads; embed HTML sets `name="theme-color"`.
- Branch to `embedResponse` in `api/convert.ts` and `src/vite-api-plugin.ts` when `isEmbedUserAgent` matches and neither Markdown nor JSON was requested; honor `Accept: text/markdown` via `wantsMarkdown`. Compute oEmbed origin with `requestOrigin` using an allowlist (`x.pcstyle.dev`, `x-md.vercel.app`, localhost) and the actual local scheme; ignore forged forwarded hosts.
- Advertise oEmbed via `<link rel="alternate" type="application/json+oembed" href="...&url=...">`; add `GET /oembed` (`vercel.json` rewrite) returning `type=link` with provider and status URL mapping. Allow `/oembed` in `robots.txt`.
- Tighten media fallbacks: scope mosaics to the same media source (own vs quoted), exclude HLS (`.m3u8`) from `og:video`, and prefer highest-bitrate MP4 for `twitter:player:stream`.
- Update headers to `Vary: Accept, User-Agent`; embed responses set CDN TTL via `Vercel-CDN-Cache-Control` (tunable by `CACHE_TTL_SECONDS`).
- Tests cover UA detection, Accept/format precedence, multi-image/mosaic selection, HLS fallback, tag output, oEmbed shaping, count formatting, and origin derivation.

No migration required. Verify by pasting a status URL in Discord; if a cached preview appears, append `?` once. Optional: tune `CACHE_TTL_SECONDS`.

<sup>Written for commit 9e26bf5602d3eb51ba1e1689cc1e11b6d34f7ff8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pc-style/x-md/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

