### PR TITLE
docs: trim AGENTS.md and browse-x skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,10 @@
 # x-md
 
 - Pages: `index.html` (`src/main.ts`), `docs.html` (`src/docs.ts`). Shared chrome in `src/chrome.ts`. `/docs` rewrites to `/docs.html` in `vercel.json` and is a Rollup input in `vite.config.ts`.
-- Tokens are the Tailwind v4 `@theme` block in `src/style.css` (`ink`..`ink-4`, `surface`, `raised`, `raised-2`, `line`, `hair`, `accent`, `accent-deep`, `accent-soft`, `cyan`, dark `code`/`code-ink`/`code-dim`). Use them, not hex.
+- Tokens are the Tailwind v4 `@theme` block in `src/style.css` (`ink`, `ink-2`, `ink-3`, `ink-4`, `surface`, `raised`, `raised-2`, `line`, `hair`, `accent`, `accent-deep`, `accent-soft`, `cyan`, dark `code`/`code-ink`/`code-dim`). Use them, not hex.
 - Look: warm paper `#f7f6f2`, Satoshi, deep green `#146c43`, pill buttons, 16px cards, near-black code panes. Not pcstyle.dev styling.
 - Landing copy frame (Theo's feedback): "Tweets are just markdown now", what-you-see vs what-your-agent-sees curl comparison in the `#how` bento, skill install under `#agents`. No stack or provider talk on the landing page.
 - Motion: GSAP + ScrollTrigger in `setupMotion` (`src/main.ts`), all gated by `prefers-reduced-motion` via `gsap.matchMedia`.
 - Status URLs serve Markdown by default. Discord, Telegram, and Slack preview bots get Open Graph HTML from `lib/embed.ts` via `api/convert.ts`; `GET /oembed` rewrites to `api/oembed.ts`.
-- Commit freely and push your own branches. Ask once before pushing to `main`, then keep going for the job.
+- Deploy: Vercel after `bun run build`. `vercel.json` configures `dist`, the API handlers, and the public route rewrites.
+- Commit freely and push your own branches without asking. Pushing to `main` needs one explicit ok per job: wait for it, and that one approval covers every later push in the same job.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,9 @@
-# Agent notes
+# x-md
 
-## Frontend structure
-
-- Pages: `index.html` (`src/main.ts`), `docs.html` (`src/docs.ts`)
-- Shared header/footer/mobile menu: `src/chrome.ts`
-- Design tokens live in the Tailwind v4 `@theme` block in `src/style.css` (semantic colors: `ink`/`ink-2`/`ink-3`/`ink-4`, `surface`, `raised`, `raised-2`, `line`, `hair`, `accent`, `accent-deep`, `accent-soft`, `cyan`, plus dark `code`/`code-ink`/`code-dim` for code panes). Use these utilities instead of hard-coded hex values in markup.
-- Visual language: light warm paper (`#f7f6f2`) with Satoshi (Fontshare), deep green accent (`#146c43`), pill buttons, 16px-radius cards, and dark near-black code panes for contrast. No pcstyle.dev styling.
-- Landing copy frame (per Theo feedback): "Tweets are just markdown now", what-you-see vs what-your-agent-sees curl comparison in the bento under `#how`, skill install under `#agents`. No tech-stack/provider-chain talk on the landing page.
-- Homepage motion uses GSAP + ScrollTrigger (`setupMotion` in `src/main.ts`): hero stagger, scrubbing word reveal (`[data-scrub-text]`), card rises (`[data-rise-card]`), and a desktop-only pinned split (`[data-pin-section]`/`[data-pin-target]`). All motion is gated behind `prefers-reduced-motion` via `gsap.matchMedia`.
-- `/docs` is rewritten to `/docs.html` in `vercel.json` and registered as a Rollup input in `vite.config.ts`.
-- Status URLs serve Markdown by default. Discord/Telegram/Slack preview bots get Open Graph HTML from `lib/embed.ts` via `api/convert.ts`; `GET /oembed` is rewritten to `api/oembed.ts`.
+- Pages: `index.html` (`src/main.ts`), `docs.html` (`src/docs.ts`). Shared chrome in `src/chrome.ts`. `/docs` rewrites to `/docs.html` in `vercel.json` and is a Rollup input in `vite.config.ts`.
+- Tokens are the Tailwind v4 `@theme` block in `src/style.css` (`ink`..`ink-4`, `surface`, `raised`, `raised-2`, `line`, `hair`, `accent`, `accent-deep`, `accent-soft`, `cyan`, dark `code`/`code-ink`/`code-dim`). Use them, not hex.
+- Look: warm paper `#f7f6f2`, Satoshi, deep green `#146c43`, pill buttons, 16px cards, near-black code panes. Not pcstyle.dev styling.
+- Landing copy frame (Theo's feedback): "Tweets are just markdown now", what-you-see vs what-your-agent-sees curl comparison in the `#how` bento, skill install under `#agents`. No stack or provider talk on the landing page.
+- Motion: GSAP + ScrollTrigger in `setupMotion` (`src/main.ts`), all gated by `prefers-reduced-motion` via `gsap.matchMedia`.
+- Status URLs serve Markdown by default. Discord, Telegram, and Slack preview bots get Open Graph HTML from `lib/embed.ts` via `api/convert.ts`; `GET /oembed` rewrites to `api/oembed.ts`.
+- Commit freely and push your own branches. Ask once before pushing to `main`, then keep going for the job.

--- a/skills/browse-x/SKILL.md
+++ b/skills/browse-x/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browse-x
-description: Read public X (Twitter) posts, threads, profiles, search, followers, or following.
+description: Read public X (Twitter) posts, threads, profiles, search, followers, or following via x.pcstyle.dev, as Markdown or JSON.
 allowed-tools:
   - Bash(skills/browse-x/scripts/browse-x.sh *)
   - Bash(curl *x.pcstyle.dev*)
@@ -8,22 +8,25 @@ allowed-tools:
 
 # browse X
 
-Hosted read-only API at x.pcstyle.dev. No login, cookies, or key. Public content only.
+Hosted read-only API at x.pcstyle.dev. No checkout, login, cookies, or key. Public content only. Install elsewhere with the skills CLI (`npx skills add pc-style/x-md`).
 
 ```bash
-S=skills/browse-x/scripts/browse-x.sh
-$S "https://x.com/handle/status/123"                         # compact markdown thread
-$S status <url> --thread off|20|full --context thread|full --replies top|recent|off --full
-$S profile @handle --limit 20
-$S followers handle --limit 50
-$S following handle --page 2 --full
-$S search "from:handle release" --feed latest|top|media --page 3 --limit 10
-$S search "typescript" --cursor '<nextCursor>'
+skills/browse-x/scripts/browse-x.sh "https://x.com/handle/status/123"
+skills/browse-x/scripts/browse-x.sh status "https://x.com/handle/status/123" --thread 20 --context thread --replies top --userinfo author --full
+skills/browse-x/scripts/browse-x.sh profile @handle --limit 20
+skills/browse-x/scripts/browse-x.sh followers handle --limit 50
+skills/browse-x/scripts/browse-x.sh following handle --page 2 --full
+skills/browse-x/scripts/browse-x.sh search "from:handle release" --feed latest
+skills/browse-x/scripts/browse-x.sh search "typescript" --feed media --page 3 --limit 10
+skills/browse-x/scripts/browse-x.sh search "typescript" --cursor "<nextCursor>"
 ```
 
-Direct API: `curl -sS -G https://x.pcstyle.dev/api/convert --data-urlencode url=<url> -H 'Accept: text/markdown'`, or rewrite a status URL to `https://x.pcstyle.dev/:handle/status/:id`.
+Status options: `--thread` is `full` (default), `off`, `conversation`, or 2-100. `--context` is `full` or `thread` (direct author chain). `--replies` is `top`, `recent`, or `off`. `--userinfo` is `off`, `author`, or `all`. Search `--feed` is `latest` (default), `top`, or `media`.
 
-- `--full` expands metadata. `--json` returns the whole response (posts, users, media, `nextCursor`, `warnings`, `source`). `--format obsidian` adds frontmatter. `--headers` prints response headers. `--nocache` bypasses the cache.
+Direct API: `curl -sS -G https://x.pcstyle.dev/api/convert --data-urlencode "url=https://x.com/handle/status/123" -H "Accept: text/markdown"`, or rewrite a status URL to `https://x.pcstyle.dev/:handle/status/:id`.
+
+- `--full` expands metadata. `--json` returns the whole response (posts, users, media, `nextCursor`, `warnings`, `source`). `--format obsidian` (status only) adds frontmatter. `--headers` prints response headers. `--nocache` bypasses the cache.
 - `--page` caps at 10, `--limit` at 50. Prefer the opaque cursor for continuation.
+- Profiles return details and recent original posts. The upstream API exposes no pinned-post markers; don't invent them.
 - Video isn't downloaded; links are preserved.
 - Exit 2 is bad usage, 1 is network or API error. Private, deleted, or gated posts can't be read. Fallback sources may omit replies, quotes, or media; check `warnings` instead of inventing content.

--- a/skills/browse-x/SKILL.md
+++ b/skills/browse-x/SKILL.md
@@ -1,93 +1,29 @@
 ---
 name: browse-x
-description: >-
-  Reads public X (Twitter) statuses and conversations, profiles, search results,
-  followers, and following through x.pcstyle.dev. Use when an agent needs X
-  content as compact or full Markdown or JSON without cloning a repository.
+description: Read public X (Twitter) posts, threads, profiles, search, followers, or following.
 allowed-tools:
   - Bash(skills/browse-x/scripts/browse-x.sh *)
   - Bash(curl *x.pcstyle.dev*)
 ---
 
-# Browse X through x.pcstyle.dev
+# browse X
 
-Use the hosted, read-only API. It needs no repository checkout, Bun install, X
-login, cookies, or API key. Only public X content is available.
-
-## Read statuses and conversations
+Hosted read-only API at x.pcstyle.dev. No login, cookies, or key. Public content only.
 
 ```bash
-skills/browse-x/scripts/browse-x.sh \
-  "https://x.com/handle/status/1234567890"
-
-skills/browse-x/scripts/browse-x.sh status \
-  "https://x.com/handle/status/1234567890" \
-  --thread full --context full --replies top --userinfo author --full
+S=skills/browse-x/scripts/browse-x.sh
+$S "https://x.com/handle/status/123"                         # compact markdown thread
+$S status <url> --thread off|20|full --context thread|full --replies top|recent|off --full
+$S profile @handle --limit 20
+$S followers handle --limit 50
+$S following handle --page 2 --full
+$S search "from:handle release" --feed latest|top|media --page 3 --limit 10
+$S search "typescript" --cursor '<nextCursor>'
 ```
 
-The default is a compact Markdown conversation (`thread=full`), including the
-parent context and selected replies. Use `--thread off` for one status,
-`--thread 20` to cap the conversation, `--context thread` for only the direct
-author chain, or `--replies recent|off` to change reply inclusion.
+Direct API: `curl -sS -G https://x.pcstyle.dev/api/convert --data-urlencode url=<url> -H 'Accept: text/markdown'`, or rewrite a status URL to `https://x.pcstyle.dev/:handle/status/:id`.
 
-The equivalent API request is:
-
-```bash
-curl -sS -G "https://x.pcstyle.dev/api/convert" \
-  --data-urlencode "url=https://x.com/handle/status/1234567890" \
-  --data-urlencode "thread=full" -H "Accept: text/markdown"
-```
-
-Direct status rewrites also work at
-`https://x.pcstyle.dev/:handle/status/:id`.
-
-## Browse profiles and people
-
-```bash
-skills/browse-x/scripts/browse-x.sh profile @handle --limit 20
-skills/browse-x/scripts/browse-x.sh "https://x.com/handle" --full
-skills/browse-x/scripts/browse-x.sh followers handle --limit 50
-skills/browse-x/scripts/browse-x.sh following handle --page 2 --full
-```
-
-Profiles return profile details and original recent posts. The upstream API
-does not expose pinned-post markers. Followers and following return users. `--full` adds metrics, dates,
-descriptions, and counts; compact Markdown is the default.
-
-## Search and pagination
-
-```bash
-skills/browse-x/scripts/browse-x.sh search "from:handle release" --feed latest
-skills/browse-x/scripts/browse-x.sh search "typescript" --feed media --page 3 --limit 10
-skills/browse-x/scripts/browse-x.sh search "typescript" --cursor '<opaque cursor>'
-```
-
-Search feeds are `latest` (default), `top`, and `media`. `--page` walks from the
-first page and is capped at 10; `--limit` is capped at 50. Prefer the opaque
-cursor from the Markdown `Continue` link or JSON `nextCursor` for reliable
-continuation. When a cursor is supplied, the API fetches that continuation
-directly and ignores page walking.
-
-## Output, source, and video
-
-- Markdown is compact by default. `--full` expands metadata, while `--format
-  obsidian` adds frontmatter and post headings for statuses.
-- `--json` returns the complete response object rather than extracting its
-  Markdown field. Use JSON when an agent needs structured posts, users, media,
-  `nextCursor`, warnings, or the status `source` provider.
-- Status responses expose the fetch provider in JSON `source` and the
-  `X-Source` header. Add `--headers` to print response headers before the body;
-  it also exposes `X-Cache`, status count, and browse resource metadata.
-- Video isn't downloaded or transcoded. Markdown preserves video/media links
-  supplied by the source, while JSON preserves the structured media and source
-  URLs an agent should inspect or hand to a separate downloader.
-- `--nocache` bypasses the hosted cache. Set `X_API_BASE` (or legacy
-  `X_MD_API_BASE`) only when testing another compatible deployment.
-
-## Errors and limits
-
-The helper exits 2 for invalid CLI usage and 1 for network or non-2xx API
-responses, printing the API error body to stderr. Private, deleted, gated, or
-unavailable posts can't be read. Fallback sources can omit conversation posts,
-articles, quotes, or media; check JSON `warnings` and `source` rather than
-inventing missing content.
+- `--full` expands metadata. `--json` returns the whole response (posts, users, media, `nextCursor`, `warnings`, `source`). `--format obsidian` adds frontmatter. `--headers` prints response headers. `--nocache` bypasses the cache.
+- `--page` caps at 10, `--limit` at 50. Prefer the opaque cursor for continuation.
+- Video isn't downloaded; links are preserved.
+- Exit 2 is bad usage, 1 is network or API error. Private, deleted, or gated posts can't be read. Fallback sources may omit replies, quotes, or media; check `warnings` instead of inventing content.


### PR DESCRIPTION
Agent instructions here had grown long and the browse-x skill description was a paragraph, which makes skill routing worse as more skills load.

Both files are rewritten shorter: one-line skill description, commands grouped into a single block, AGENTS.md as a flat list of facts. Adds the commit/push policy (commit freely, own branches always, main after one ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shortens agent instructions and the browse-x skill so skill routing works better as more skills load. Rewrites AGENTS.md as a flat list of facts and the skill's body as a single command block with a one-line description. Adds a commit/push policy: commit freely and push own branches without asking; pushing to main needs one explicit ok per job.

<sup>Written for commit 74e371f6dc7c770b92d458a3127905aefff5c30c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pc-style/x-md/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

