### PR TITLE
feat: add opt-in PostHog dataset capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Successful responses are cached for about one hour by default (`CACHE_TTL_SECOND
 - The hosted service receives the public X URL, handle, or search query you request and sends it to FxTwitter or X's public syndication service. Successful results are cached for about one hour and can be served to other callers requesting the same public resource.
 - Optional Context.dev and Firecrawl fallbacks are disabled unless a self-hosted operator configures their API keys. When enabled, the public X URL is sent to that provider.
 - The hosted `browse-x` skill sends its arguments to `x.pcstyle.dev`. Do not put secrets or private-account information in URLs or search terms.
+- Optional, disabled-by-default PostHog dataset capture archives allowlisted structured public results, not just metrics. See the [archive/privacy policy](docs/archive.mdx) for actor pseudonyms, opt-out controls, retention duties, and delivery limits.
 - Media links point to upstream X/FxTwitter CDNs. Fetching those links is outside x.md's cache and privacy boundary.
 
 x.md is read-only and does not accept X credentials, post content, or account mutations. It is the canonical implementation, has no successor, and is not affiliated with X Corp.

--- a/api/browse.ts
+++ b/api/browse.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { trackRequest } from '../lib/analytics.js'
+import { captureArchive } from '../lib/archive.js'
 import { callerHeaders, resolveCaller } from '../lib/apiauth.js'
 import { browse, browseResponse } from '../lib/browse.js'
 import { ConvertError } from '../lib/errors.js'
@@ -28,6 +29,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     for (const [key, header] of Object.entries(response.headers)) res.setHeader(key, header)
     // Keyed responses stay private even if the browse layer marked them cacheable.
     for (const [key, value] of Object.entries(callerHeaders(resolved))) res.setHeader(key, value)
+    if (response.status === 200) captureArchive(req, res, result, identity)
     return req.method === 'HEAD' ? res.status(response.status).end() : res.status(response.status).send(response.body)
   } catch (error) {
     if (error instanceof ConvertError) {

--- a/api/convert.ts
+++ b/api/convert.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { trackRequest } from '../lib/analytics.js'
+import { captureArchive } from '../lib/archive.js'
 import { ConvertError, acceptPrefersHtml, convertTweet, markdownResponse } from '../lib/converter.js'
 import { embedResponse, isEmbedUserAgent } from '../lib/embed.js'
 import { requestOrigin, setCorsHeaders, wantsJson, wantsMarkdown } from '../lib/http.js'
@@ -42,6 +43,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     for (const [key, value] of Object.entries(headers)) {
       res.setHeader(key, value)
     }
+
+    if (status === 200) captureArchive(req, res, { ...result, resource: 'tweet', degraded: result.source !== 'fxtwitter' })
 
     if (req.method === 'HEAD') {
       return res.status(status).end()

--- a/docs/archive.env.example
+++ b/docs/archive.env.example
@@ -1,0 +1,8 @@
+# Optional production-only public-result archive. Read docs/archive.mdx first.
+# Disabled by default; these do not enable paid provider fallbacks.
+XMD_ARCHIVE_ENABLED=false
+XMD_ARCHIVE_ACTOR_SECRET=
+POSTHOG_PROJECT_TOKEN=
+POSTHOG_HOST=
+# Optional anonymous same-origin browser cookie bridge (build-time, HTTPS only).
+VITE_XMD_ARCHIVE_ACTOR_BRIDGE=false

--- a/docs/archive.mdx
+++ b/docs/archive.mdx
@@ -1,0 +1,74 @@
+---
+title: Optional data archive
+description: Public-result capture through PostHog, privacy controls, and export contract.
+sidebar:
+  order: 9
+  icon: database
+---
+
+## Disabled by default
+
+The optional archive sends useful structured public results from completed HTTP `200` GET responses in the production convert and browse functions to PostHog. This includes application-cache hits and profile, search, followers, and following results. It does not make additional X/provider calls. Ordinary `request_completed` and landing-page events remain metadata-only; their allowlists are unchanged.
+
+Enable only after reviewing data rights, your privacy notice, PostHog retention, project access, billing, and any required consent. This repository change does not enable or deploy capture. Set all of:
+
+- `XMD_ARCHIVE_ENABLED=true`
+- `VERCEL_ENV=production`
+- `POSTHOG_PROJECT_TOKEN` and an HTTPS `POSTHOG_HOST` (the existing `NEXT_PUBLIC_POSTHOG_*` integration variables also work).
+- `XMD_ARCHIVE_ACTOR_SECRET`: a separate random server-only secret of at least 32 characters. Never use an admin token or put this in a `VITE_` variable. Rotating it breaks linkage to older actors.
+
+No personal PostHog API key is needed for capture. Export credentials belong in a restricted offline export job, not the browser or public API. The Vite development middleware does not archive.
+
+## Data and privacy boundary
+
+This is a **content archive**, not anonymous aggregate analytics. Public post text, articles, media metadata, public author/profile fields, and social connections can identify X users. Review whether you have permission to retain and redistribute them. Public availability does not itself grant reuse rights.
+
+Archive payloads use explicit nested field allowlists. They exclude rendered Markdown/response bodies, incoming URLs and search queries, request headers, IPs, credentials, API-key labels, cursors, unknown provider fields, and unstructured community notes. Public content URLs are allowed, but only HTTPS URLs without user credentials. URL query strings and fragments are removed: signed links or media URLs that depend on query parameters may stop working. Unknown or unmodeled fields are omitted, so this is not a lossless copy of provider responses. Warning text is reduced to the fixed code `source_result_warning`, not copied from arbitrary upstream messages.
+
+Protected authors are excluded, including nested quoted/reposted authors. A protected profile excludes its entire returned timeline. Only public-result routes are wired: no admin, private-account, personalized home-timeline, or credential-management routes. Filtering relies on upstream protection flags and cannot prove that content will remain public. Operators must define retention, deletion/takedown, and downstream access rules before enabling capture; the repository does not automate PostHog or downstream deletion.
+
+## Actor association and opt-out
+
+Archive `distinct_id` is separate from the content payload:
+
+- A verified internal API-key ID is HMAC-hashed with the archive secret. Raw keys, internal IDs, and key labels are not sent.
+- Optionally, an anonymous website actor UUID is read from a same-origin cookie and HMAC-hashed with a separate namespace.
+- Otherwise a fresh request UUID is used. It cannot identify repeat visitors.
+
+These are pseudonyms, not proof of a person's identity. Client-set cookies can be spoofed. Browser archive HMAC IDs link repeat archive requests but **do not automatically equal or join to the landing-page PostHog `distinct_id`**. Existing `request_completed` key pseudonyms also use a different derivation. No identity map or alias event is sent. Do not send archive actors to Xearch ingress.
+
+The optional browser cookie bridge needs a rebuild with `VITE_XMD_ARCHIVE_ACTOR_BRIDGE=true`, plus existing production landing-page PostHog settings and HTTPS. It is off by default. The bridge copies only an anonymous UUID, never an identified user's ID, into `__Host-xmd_actor` with `Secure; SameSite=Lax; Path=/; Max-Age=2592000` and no Domain. JavaScript must read/write it, so it is not HttpOnly. It is not placed in a URL, response body, response header, or application/shared cache entry. API handlers never set actor cookies. A website visit may establish the cookie; direct API callers generally have no cookie.
+
+This is an operator opt-in, not a consent-management UI. Where prior visitor consent is required, keep the bridge disabled until your consent system permits it. The bridge checks the SDK capture opt-out, DNT, GPC, and `__Host-xmd_archive_optout=1`, and clears its actor cookie on the next bridge check when opted out. Server archive capture honors that opt-out cookie, `DNT: 1`, `Sec-GPC: 1`, or `X-Xmd-Archive-Opt-Out: 1`. API clients can send the latter header directly. SDK opt-out stored only in browser local storage cannot be read by the server; the landing-page bridge mirrors it into the opt-out cookie when it runs. Clearing only the actor cookie removes repeat-actor association, not public-result capture. Cross-origin requests do not get credentialed CORS access. These archive controls do not change the separate server `request_completed` metadata instrumentation or Vercel analytics.
+
+## Export contract v1
+
+Event name: `xmd_data_captured`. PostHog properties:
+
+```json
+{
+  "archive_schema_version": 1,
+  "request_id": "UUID shared by all chunks of one response",
+  "captured_at": "ISO timestamp",
+  "resource": "tweet",
+  "http_status": 200,
+  "source": "fxtwitter",
+  "cache": "hit",
+  "degraded": false,
+  "chunk_index": 0,
+  "chunk_count": 1,
+  "payload": { "posts": [], "users": [] }
+}
+```
+
+`resource` is `tweet`, `profile`, `search`, `followers`, or `following`. `payload.posts` contains structured `FxTweet` objects; `payload.users` and optional `payload.profile` contain structured `FxAuthor` objects. These types are in `lib/fxtwitter.ts`. Optional `warnings` is a string-code array. `cache` is omitted when unavailable. PostHog privacy properties disable person profiles and IP enrichment. Source/degraded flags distinguish fallbacks; captured data is not necessarily complete, live, or untruncated upstream.
+
+Each record occurs in one chunk, without splitting or truncating the record. The serialized UTF-8 capture envelope (including token and PostHog fields) stays below 190,000 bytes. Empty/non-useful results are skipped. If an individual record cannot fit, the **entire request archive is rejected before any chunk is sent**, with fixed log reason `archive_record_oversized`. Excessive nested quote depth is similarly rejected. No raw record is logged.
+
+Export only this event with schema version 1 and HTTP status 200. Export adapters must parse properties supplied either as an object or as a JSON-encoded string. Group by `request_id`; verify unique zero-based indexes and matching `chunk_count` before treating a response as complete. Import public `payload` records, source, timestamps and quality metadata into Xearch batches, not `distinct_id`, cookies, or PostHog/export credentials. Use stable public X record IDs for downstream upserts/deduplication; repeat requests and exports can contain the same records.
+
+## Delivery limits
+
+Delivery starts on response `finish` through Vercel `waitUntil`. Each chunk has a three-second fetch timeout. The first failed chunk stops delivery and emits a fixed, non-sensitive warning. A successful HTTP acknowledgement is not proof of durable retention. There is no retry queue, durable outbox, automatic reconciliation, or completeness guarantee; earlier chunks can have arrived before a later failure. Oversized-record failures leave that request absent from the archive.
+
+CDN hits never run these functions. HEAD, OPTIONS, non-200 responses, disconnected requests, local/preview traffic, admin routes, empty results, opt-outs, and disabled/misconfigured capture do not archive. Platform failures, browser blocking, and failed delivery further limit coverage. Cookie/CDN behavior and ad blockers can prevent actor linkage. This is a best-effort dataset feed, not complete traffic capture or a billing ledger.

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -68,7 +68,7 @@ PostHog is optional. Connect its Vercel Marketplace integration to the productio
 
 Production API functions send a `request_completed` event with the route category, method, HTTP status, duration in milliseconds, application-cache result, key-validation status, public/key access, and degraded-search flag. Use these for request volume by endpoint, error and `429` rates, latency percentiles, and application-cache hit rate. Delivery runs in the background with a three-second timeout; failures do not change API responses.
 
-Events contain no search text, URLs, client IPs, bearer tokens, or key labels. Verified keys use a pseudonymous ID derived from their internal ID and the PostHog project token; rotating that token changes the pseudonyms. Public requests have a new ID per event, so distinct-user counts and anonymous retention are not meaningful. Person profiles, geolocation enrichment, and session replay are not enabled by this instrumentation.
+`request_completed` events contain no search text, URLs, client IPs, bearer tokens, or key labels. Verified keys use a pseudonymous ID derived from their internal ID and the PostHog project token; rotating that token changes the pseudonyms. Public requests have a new ID per event, so distinct-user counts and anonymous retention are not meaningful. Person profiles, geolocation enrichment, and session replay are not enabled by this instrumentation.
 
 These statistics cover completed function responses, not requests served by Vercel's CDN, aborted requests, or platform errors before the handler runs. They are not billing-grade totals. Local development, previews, admin routes, and CORS preflights are excluded. Redis remains the source of truth for live limits and capacity; PostHog is only for historical analysis.
 
@@ -79,6 +79,10 @@ Set `VITE_POSTHOG_KEY` to the project token and `VITE_POSTHOG_HOST` to its inges
 The landing page sends pageviews, page leaves, `conversion_requested`, and `skill_install_command_copied`. Anonymous browser IDs persist in local storage to measure returning visitors; session and browser/device properties support Web Analytics. No person profiles are created. Event URLs contain only the landing-page origin and `/`, without query strings or fragments. Referrers, form contents, automatic clicks, errors, and recordings are excluded; traffic-source attribution and geographic reports are therefore limited. The proxy receives the browser's source IP, while event properties disable IP-based enrichment.
 
 This covers the landing page only, not docs, converted posts, or admin. API events remain separate from browser visits. Existing Vercel Web Analytics on the public landing page is unchanged. The admin dashboard includes no analytics scripts.
+
+## Optional public-result archive
+
+A separate, disabled-by-default content archive can send structured public results to PostHog for later dataset export. It has different privacy and retention implications from request metrics. Read the [archive policy and v1 contract](/docs/archive) before enabling it.
 
 ## Optional configuration
 

--- a/lib/archive-handlers.test.ts
+++ b/lib/archive-handlers.test.ts
@@ -1,0 +1,77 @@
+import { IncomingMessage, ServerResponse } from 'node:http'
+import { Socket } from 'node:net'
+import { beforeEach, afterEach, expect, test, vi } from 'vitest'
+import { waitUntil } from '@vercel/functions'
+import convertHandler from '../api/convert.js'
+import browseHandler from '../api/browse.js'
+import { convertTweet, ConvertError } from './converter.js'
+import { browse } from './browse.js'
+import { resolveCaller } from './apiauth.js'
+
+vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }))
+vi.mock('./converter.js', async importOriginal => ({ ...await importOriginal<any>(), convertTweet: vi.fn() }))
+vi.mock('./browse.js', async importOriginal => ({ ...await importOriginal<any>(), browse: vi.fn() }))
+vi.mock('./apiauth.js', async importOriginal => ({ ...await importOriginal<any>(), resolveCaller: vi.fn() }))
+const fetchMock = vi.fn()
+const posts = [{ id: '123', text: 'public result', author: { screen_name: 'user' } }]
+function exchange(method = 'GET', resource = 'search') {
+  const req = new IncomingMessage(new Socket()) as any
+  req.method = method; req.query = { resource, q: 'private-query', handle: 'user', id: '123' }
+  req.headers = { accept: 'application/json' }
+  const res = new ServerResponse(req) as any
+  res.status = (code: number) => { res.statusCode = code; return res }
+  res.send = res.json = res.end = () => { res.emit('finish'); return res }
+  return { req, res }
+}
+async function events() {
+  await Promise.all(vi.mocked(waitUntil).mock.calls.map(call => call[0]))
+  return fetchMock.mock.calls.map(call => JSON.parse(call[1].body))
+}
+beforeEach(() => {
+  vi.clearAllMocks(); vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockResolvedValue(new Response('{}', { status: 200 }))
+  vi.stubEnv('VERCEL_ENV', 'production'); vi.stubEnv('XMD_ARCHIVE_ENABLED', 'true')
+  vi.stubEnv('POSTHOG_PROJECT_TOKEN', 'phc_test'); vi.stubEnv('POSTHOG_HOST', 'https://eu.i.posthog.com')
+  vi.stubEnv('XMD_ARCHIVE_ACTOR_SECRET', 'secret-at-least-thirty-two-characters')
+  vi.mocked(convertTweet).mockResolvedValue({ posts, body: 'private-rendered-markdown', warnings: [], canonicalUrl: 'https://x.com/user/status/123', format: 'json', postCount: 1, source: 'fxtwitter', cache: 'hit', compact: true })
+  vi.mocked(browse).mockResolvedValue({ resource: 'search', posts, query: 'private-query', page: 1, limit: 20, source: 'xsearch', markdown: 'private-rendered-markdown', cache: 'hit' })
+  vi.mocked(resolveCaller).mockResolvedValue({ caller: { kind: 'public' }, status: 'anonymous', ip: '192.0.2.1' })
+})
+afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+test.each([convertHandler, browseHandler])('real handler emits separate completed metadata and structured archive', async handler => {
+  const { req, res } = exchange(); await handler(req, res)
+  const sent = await events()
+  expect(res.statusCode).toBe(200)
+  expect(sent.map(event => event.event).sort()).toEqual(['request_completed', 'xmd_data_captured'])
+  expect(sent.find(event => event.event === 'request_completed').properties.payload).toBeUndefined()
+  expect(sent.find(event => event.event === 'xmd_data_captured').properties.payload.posts).toEqual(posts)
+  expect(JSON.stringify(sent)).not.toContain('private-')
+  expect(res.getHeader('Set-Cookie')).toBeUndefined()
+})
+
+test.each([convertHandler, browseHandler])('HEAD only emits metadata, errors never archive', async handler => {
+  const { req, res } = exchange('HEAD'); await handler(req, res)
+  expect((await events()).map(event => event.event)).toEqual(['request_completed'])
+  vi.mocked(convertTweet).mockRejectedValue(new ConvertError(404, 'not found', 'not_found'))
+  vi.mocked(browse).mockRejectedValue(new ConvertError(404, 'not found', 'not_found'))
+  const failure = exchange(); await handler(failure.req, failure.res)
+  expect(failure.res.statusCode).toBe(404)
+  expect((await events()).every(event => event.event === 'request_completed')).toBe(true)
+})
+
+test('invalid API key returns 401 without browsing or archive', async () => {
+  vi.mocked(resolveCaller).mockResolvedValue({ caller: { kind: 'public' }, status: 'invalid', ip: '192.0.2.1' })
+  const { req, res } = exchange(); await browseHandler(req, res)
+  expect(res.statusCode).toBe(401); expect(browse).not.toHaveBeenCalled()
+  expect((await events()).map(event => event.event)).toEqual(['request_completed'])
+})
+
+test('verified key actor never enters public response or payload', async () => {
+  vi.mocked(resolveCaller).mockResolvedValue({ caller: { kind: 'key', id: 'private-internal-key', limit: 10 }, status: 'valid', ip: '192.0.2.1' })
+  const { req, res } = exchange(); await browseHandler(req, res)
+  const archive = (await events()).find(event => event.event === 'xmd_data_captured')
+  expect(archive.distinct_id).toMatch(/^key:[a-f0-9]{64}$/)
+  expect(res.getHeader('Cache-Control')).toBe('private, no-store')
+  expect(JSON.stringify(archive)).not.toContain('private-')
+})

--- a/lib/archive.test.ts
+++ b/lib/archive.test.ts
@@ -1,0 +1,169 @@
+import { IncomingMessage, ServerResponse } from 'node:http'
+import { Socket } from 'node:net'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { waitUntil } from '@vercel/functions'
+import { buildArchiveEvents, captureArchive, MAX_ARCHIVE_EVENT_BYTES, type ArchiveInput } from './archive.js'
+
+vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }))
+const fetchMock = vi.fn()
+const input: ArchiveInput = { resource: 'tweet', source: 'fxtwitter', cache: 'hit', posts: [{ id: '123', text: 'public post', author: { id: '1', screen_name: 'user' } }] }
+const options = { token: 'phc_test', distinctId: 'anonymous:test', requestId: 'c48b54a6-6466-4f92-8b8c-ff9c7e59e202', capturedAt: '2026-09-07T00:00:00.000Z' }
+function request(method = 'GET') {
+  const req = new IncomingMessage(new Socket())
+  req.method = method
+  req.url = '/search?q=private-query'
+  req.headers = { authorization: 'Bearer private-token', 'x-real-ip': '192.0.2.44' }
+  return { req, res: new ServerResponse(req) }
+}
+async function finish(res: ServerResponse) {
+  res.emit('finish'); res.emit('close')
+  await Promise.all(vi.mocked(waitUntil).mock.calls.map(call => call[0]))
+}
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubEnv('VERCEL_ENV', 'production'); vi.stubEnv('XMD_ARCHIVE_ENABLED', 'true')
+  vi.stubEnv('POSTHOG_PROJECT_TOKEN', 'phc_test'); vi.stubEnv('POSTHOG_HOST', 'https://eu.i.posthog.com')
+  vi.stubEnv('XMD_ARCHIVE_ACTOR_SECRET', 'secret-with-at-least-thirty-two-characters')
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockResolvedValue(new Response('{}', { status: 200 }))
+})
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllEnvs(); vi.unstubAllGlobals() })
+
+test('v1 archive preserves useful structured records, never response/request fields', () => {
+  const [event] = buildArchiveEvents({ ...input, markdown: 'private-markdown', body: 'private-body', query: 'private-query',
+    warnings: ['private-warning'], posts: [{ ...input.posts![0], private_field: 'private-content',
+      url: 'https://x.com/user/status/123?secret=private-url',
+      author: { id: '1', screen_name: 'user', email: 'private-email', website: { url: 'https://a:b@example.com', private: 'private-website' } },
+      media: { photos: [{ url: 'https://pbs.twimg.com/media/image', width: 200, private: 'private-media' }] },
+      article: { title: 'Public article', content: { blocks: [{ text: 'full article', private: 'private-article' }] } },
+      community_note: { token: 'private-note' },
+    }] } as any, options)
+  expect(event).toMatchObject({ event: 'xmd_data_captured', distinct_id: options.distinctId, properties: {
+    archive_schema_version: 1, request_id: options.requestId, captured_at: options.capturedAt,
+    http_status: 200, resource: 'tweet', source: 'fxtwitter', cache: 'hit', degraded: false,
+    chunk_count: 1, chunk_index: 0, payload: { posts: [{ text: 'public post', url: 'https://x.com/user/status/123',
+      article: { content: { blocks: [{ text: 'full article' }] } } }], users: [] }, warnings: ['source_result_warning'],
+  } })
+  expect(JSON.stringify(event)).not.toContain('private-')
+  expect(JSON.stringify(event)).not.toContain('markdown')
+})
+
+test('filters protected data, including nested quotes and entire protected profile timelines', () => {
+  const [event] = buildArchiveEvents({ ...input, posts: [
+    { id: 'private', text: 'private', author: { protected: true } },
+    { ...input.posts![0], quote: { id: 'hidden', text: 'private', author: { protected: true } } },
+  ], users: [{ id: 'private', protected: true }, { id: 'public' }] }, options)
+  expect(event.properties.payload.posts).toHaveLength(1)
+  expect(event.properties.payload.posts[0].quote).toBeUndefined()
+  expect(event.properties.payload.users).toEqual([{ id: 'public' }])
+  expect(buildArchiveEvents({ ...input, profile: { id: 'private', protected: true } }, options)).toEqual([])
+  expect(buildArchiveEvents({ ...input, posts: [{ id: 'empty' }, {}], users: [{}] }, options)).toEqual([])
+})
+
+test.each(['profile', 'search', 'followers', 'following'] as const)('captures useful %s results', resource => {
+  const [event] = buildArchiveEvents({ resource, source: 'xsearch', degraded: true,
+    users: [{ id: 'user1', screen_name: 'name' }], ...(resource === 'profile' ? { profile: { id: 'profile1' } } : {}) }, options)
+  expect(event.properties.resource).toBe(resource)
+  expect(event.properties.degraded).toBe(true)
+  expect(event.properties.payload.users).toHaveLength(1)
+  expect(event.properties.payload.profile?.id).toBe(resource === 'profile' ? 'profile1' : undefined)
+})
+
+test('chunks complete UTF-8 envelopes below limit, each record exactly once with stable request identity', () => {
+  const posts = Array.from({ length: 8 }, (_, i) => ({ id: String(i), text: '🦋'.repeat(20_000) }))
+  const events = buildArchiveEvents({ ...input, posts, profile: { id: 'profile' }, users: [{ id: 'user' }] }, options)
+  expect(events.length).toBeGreaterThan(1)
+  expect(events.flatMap(event => event.properties.payload.posts)).toEqual(posts)
+  expect(events.flatMap(event => event.properties.payload.users)).toEqual([{ id: 'user' }])
+  expect(events.filter(event => event.properties.payload.profile)).toHaveLength(1)
+  expect(new Set(events.map(event => event.uuid)).size).toBe(events.length)
+  events.forEach((event, i) => {
+    expect(Buffer.byteLength(JSON.stringify(event))).toBeLessThan(MAX_ARCHIVE_EVENT_BYTES)
+    expect(event.properties).toMatchObject({ request_id: options.requestId, chunk_index: i, chunk_count: events.length })
+  })
+})
+
+test('oversized single records reject the entire archive rather than truncate', () => {
+  expect(() => buildArchiveEvents({ ...input, posts: [...input.posts!, { id: 'large', text: 'x'.repeat(200_000) }] }, options)).toThrow('archive_record_oversized')
+})
+
+test.each([
+  ['XMD_ARCHIVE_ENABLED', ''], ['XMD_ARCHIVE_ENABLED', 'false'], ['VERCEL_ENV', 'preview'],
+  ['XMD_ARCHIVE_ACTOR_SECRET', 'short'], ['POSTHOG_HOST', 'http://example.test'],
+])('safe defaults: no capture when %s=%s', (name, value) => {
+  vi.stubEnv(name, value)
+  const { req, res } = request(); captureArchive(req, res, input)
+  expect(waitUntil).not.toHaveBeenCalled()
+})
+
+test.each(['HEAD', 'OPTIONS', 'POST'])('does not capture %s', method => {
+  const { req, res } = request(method); captureArchive(req, res, input)
+  expect(waitUntil).not.toHaveBeenCalled()
+})
+
+test.each([{ dnt: '1' }, { 'sec-gpc': '1' }, { 'x-xmd-archive-opt-out': '1' }, { cookie: '__Host-xmd_archive_optout=1' }])('respects opt-out %j', headers => {
+  const { req, res } = request(); req.headers = headers; captureArchive(req, res, input)
+  expect(waitUntil).not.toHaveBeenCalled()
+})
+
+test('only captures completed wire 200, includes cache hits, never captures close without finish', async () => {
+  for (const status of [200, 206, 301, 400, 500]) {
+    const { req, res } = request(); captureArchive(req, res, input); res.statusCode = status; await finish(res)
+  }
+  expect(fetchMock).toHaveBeenCalledOnce()
+  const event = JSON.parse(fetchMock.mock.calls[0][1].body)
+  expect(event.properties.cache).toBe('hit')
+  expect(event.distinct_id).toBe(`anonymous:${event.properties.request_id}`)
+  expect(JSON.stringify(event)).not.toMatch(/private-|192\.0\.2/)
+  const { req, res } = request(); captureArchive(req, res, input); res.emit('close'); await finish(res)
+  expect(fetchMock).toHaveBeenCalledOnce()
+})
+
+test('pseudonymous actors: verified keys, browser UUID cookies, invalid-cookie per-request fallback', async () => {
+  const ids: string[] = []
+  for (const cookie of ['__Host-xmd_actor=018e7421-7573-7d04-839c-d0b005ad88ae', '__Host-xmd_actor=018e7421-7573-7d04-839c-d0b005ad88ae', '__Host-xmd_actor=private-email', '__Host-xmd_actor=%broken']) {
+    const { req, res } = request(); req.headers.cookie = cookie
+    captureArchive(req, res, input); await finish(res)
+    ids.push(JSON.parse(fetchMock.mock.calls.at(-1)![1].body).distinct_id)
+  }
+  expect(ids[0]).toMatch(/^browser:[a-f0-9]{64}$/); expect(ids[0]).toBe(ids[1]); expect(ids[2]).not.toBe(ids[3])
+  const { req, res } = request(); res.setHeader('X-Api-Key-Status', 'valid')
+  captureArchive(req, res, input, { keyId: 'private-key-id' }); await finish(res)
+  const event = JSON.parse(fetchMock.mock.calls.at(-1)![1].body)
+  expect(event.distinct_id).toMatch(/^key:[a-f0-9]{64}$/)
+  expect(JSON.stringify(event)).not.toContain('private-key-id')
+})
+
+test.each(['http', 'network', 'oversized'])('isolates %s failures with honest non-sensitive logs', async failure => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  if (failure === 'http') fetchMock.mockResolvedValue(new Response('{}', { status: 503 }))
+  if (failure === 'network') fetchMock.mockRejectedValue(new Error('private-error'))
+  const { req, res } = request()
+  captureArchive(req, res, failure === 'oversized' ? { ...input, posts: [{ id: '1', text: 'x'.repeat(200_000) }] } : input)
+  await finish(res)
+  expect(res.statusCode).toBe(200)
+  expect(warn).toHaveBeenCalledOnce(); expect(JSON.stringify(warn.mock.calls)).not.toContain('private-')
+  if (failure === 'oversized') expect(fetchMock).not.toHaveBeenCalled()
+})
+
+
+test('stops a multi-chunk delivery on rejection and does not retry or claim completeness', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }))
+    .mockResolvedValueOnce(new Response('{}', { status: 503 }))
+  const { req, res } = request()
+  captureArchive(req, res, { ...input, posts: Array.from({ length: 5 }, (_, i) => ({ id: String(i), text: 'x'.repeat(100_000) })) })
+  await finish(res)
+  expect(fetchMock).toHaveBeenCalledTimes(2)
+  expect(warn).toHaveBeenCalledWith('[archive] PostHog rejected a chunk; archive may be incomplete')
+  expect(JSON.parse(fetchMock.mock.calls[0][1].body).properties.chunk_count).toBe(5)
+  expect(res.statusCode).toBe(200)
+})
+
+test('unverified key IDs never establish a stable actor', async () => {
+  const { req, res } = request(); res.setHeader('X-Api-Key-Status', 'unverified')
+  captureArchive(req, res, input, { keyId: 'private-unverified-key' }); await finish(res)
+  const event = JSON.parse(fetchMock.mock.calls.at(-1)![1].body)
+  expect(event.distinct_id).toBe(`anonymous:${event.properties.request_id}`)
+  expect(JSON.stringify(event)).not.toContain('private-')
+})

--- a/lib/archive.test.ts
+++ b/lib/archive.test.ts
@@ -167,3 +167,15 @@ test('unverified key IDs never establish a stable actor', async () => {
   expect(event.distinct_id).toBe(`anonymous:${event.properties.request_id}`)
   expect(JSON.stringify(event)).not.toContain('private-')
 })
+
+
+test('rejects redirects so archive content cannot be replayed to another origin or HTTP', async () => {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  fetchMock.mockRejectedValue(new TypeError('redirect encountered'))
+  const { req, res } = request()
+  captureArchive(req, res, input); await finish(res)
+  expect(fetchMock).toHaveBeenCalledOnce()
+  expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'error' })
+  expect(warn).toHaveBeenCalledWith('[archive] delivery_or_serialization_failed; archive not guaranteed')
+  expect(res.statusCode).toBe(200)
+})

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -1,0 +1,205 @@
+import { createHmac, randomUUID } from 'node:crypto'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { waitUntil } from '@vercel/functions'
+import type { FxAuthor, FxTweet } from './fxtwitter.js'
+
+export const ARCHIVE_EVENT = 'xmd_data_captured'
+// UTF-8 bytes of the complete capture envelope, including token and properties.
+export const MAX_ARCHIVE_EVENT_BYTES = 190_000
+export interface ArchiveInput {
+  resource: 'tweet' | 'profile' | 'search' | 'followers' | 'following'
+  source: string
+  cache?: string
+  degraded?: boolean
+  warnings?: string[]
+  posts?: FxTweet[]
+  users?: FxAuthor[]
+  profile?: FxAuthor
+}
+export interface ArchivePayload { posts: FxTweet[]; users: FxAuthor[]; profile?: FxAuthor }
+export interface ArchiveEvent {
+  api_key: string
+  event: typeof ARCHIVE_EVENT
+  uuid: string
+  distinct_id: string
+  timestamp: string
+  properties: {
+    archive_schema_version: 1; request_id: string; captured_at: string
+    resource: ArchiveInput['resource']; http_status: 200; source: string
+    cache?: string; degraded: boolean; warnings?: string[]
+    chunk_index: number; chunk_count: number; payload: ArchivePayload
+    $process_person_profile: false; $geoip_disable: true; $ip: null
+  }
+}
+
+type Rule = 'string' | 'number' | 'boolean' | 'url' | { [key: string]: Rule } | [Rule]
+const fields = (names: string, rule: Rule): Record<string, Rule> => Object.fromEntries(names.split(' ').map(key => [key, rule]))
+const authorRule: Rule = {
+  ...fields('id name screen_name description location joined', 'string'),
+  ...fields('url avatar_url banner_url', 'url'),
+  ...fields('followers following likes media_count statuses', 'number'),
+  protected: 'boolean', website: { url: 'url', display_url: 'string' },
+  verification: { verified: 'boolean', type: 'string' },
+}
+const mediaItemRule: Rule = {
+  ...fields('type format alt altText', 'string'), ...fields('url thumbnail_url', 'url'),
+  ...fields('width height duration duration_ms bitrate', 'number'),
+  variants: [{ url: 'url', content_type: 'string', bitrate: 'number' }],
+  formats: [{ url: 'url', container: 'string', codec: 'string', bitrate: 'number' }],
+}
+const tweetRule: Rule = {
+  ...fields('id text created_at lang source context', 'string'), url: 'url',
+  ...fields('created_timestamp replies retweets reposts likes views bookmarks quotes', 'number'),
+  possibly_sensitive: 'boolean',
+  media: { photos: [mediaItemRule], videos: [mediaItemRule], animated: [mediaItemRule], all: [mediaItemRule],
+    mosaic: { type: 'string', photos: [mediaItemRule], formats: { jpeg: 'url', webp: 'url' } } },
+  poll: { choices: [{ label: 'string', count: 'number', percentage: 'number' }], total_votes: 'number', time_left_en: 'string', ends_at: 'string' },
+  article: { title: 'string', preview_text: 'string', cover_media: { media_info: { original_img_url: 'url' } },
+    content: { blocks: [{ type: 'string', text: 'string',
+      inlineStyleRanges: [{ offset: 'number', length: 'number', style: 'string' }],
+      data: { urls: [{ fromIndex: 'number', toIndex: 'number', text: 'string' }] } }] } },
+  replying_to_status: ['string'],
+}
+
+// Never spread provider objects: they can contain private/personalized additions.
+function select(value: unknown, rule: Rule): unknown {
+  if (Array.isArray(rule)) return Array.isArray(value) ? value.map(item => select(item, rule[0])).filter(item => item !== undefined) : undefined
+  if (typeof rule === 'object') {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+    return Object.fromEntries(Object.entries(rule).flatMap(([key, child]) => {
+      const selected = select((value as Record<string, unknown>)[key], child)
+      return selected === undefined ? [] : [[key, selected]]
+    }))
+  }
+  if (rule === 'url') {
+    if (typeof value !== 'string') return undefined
+    try {
+      const url = new URL(value)
+      if (url.protocol !== 'https:' || url.username || url.password) return undefined
+      url.search = ''; url.hash = ''
+      return url.toString()
+    } catch { return undefined }
+  }
+  return typeof value === rule && (rule !== 'number' || Number.isFinite(value)) ? value : undefined
+}
+function publicAuthor(value: FxAuthor | undefined): FxAuthor | undefined {
+  if (!value || value.protected === true) return undefined
+  const author = select(value, authorRule) as FxAuthor
+  return author.id || author.screen_name ? author : undefined
+}
+function publicPost(value: FxTweet, depth = 0): FxTweet | undefined {
+  if (!value || value.author?.protected === true) return undefined
+  if (depth > 12) throw new Error('archive_record_depth')
+  const post = select(value, tweetRule) as FxTweet
+  if (!post.id || !(post.text?.trim() || post.article?.title || post.media && Object.keys(post.media).length)) return undefined
+  post.author = publicAuthor(value.author)
+  post.reposted_by = publicAuthor(value.reposted_by ?? undefined)
+  if (value.quote) post.quote = publicPost(value.quote, depth + 1)
+  post.replying_to = select(value.replying_to, Array.isArray(value.replying_to) ? ['string'] : {
+    screen_name: 'string', status: 'string', url: 'url', profile_url: 'url',
+  }) as FxTweet['replying_to']
+  return post
+}
+
+/** Reject an oversized record atomically: never publish a silently truncated record. */
+export function buildArchiveEvents(input: ArchiveInput, options: {
+  token: string; distinctId: string; requestId?: string; capturedAt?: string; maxBytes?: number
+}): ArchiveEvent[] {
+  const requestId = options.requestId ?? randomUUID()
+  const capturedAt = options.capturedAt ?? new Date().toISOString()
+  const maxBytes = Math.min(options.maxBytes ?? MAX_ARCHIVE_EVENT_BYTES, MAX_ARCHIVE_EVENT_BYTES)
+  if (!['tweet', 'profile', 'search', 'followers', 'following'].includes(input.resource)) return []
+  // A protected profile must not leak its attached timeline either.
+  if (input.profile?.protected === true) return []
+  const posts = (input.posts ?? []).map(post => publicPost(post)).filter((post): post is FxTweet => !!post)
+  const users = (input.users ?? []).map(publicAuthor).filter((user): user is FxAuthor => !!user)
+  const profile = publicAuthor(input.profile)
+  const records: Array<{ kind: 'posts' | 'users' | 'profile'; value: FxTweet | FxAuthor }> = [
+    ...posts.map(value => ({ kind: 'posts' as const, value })),
+    ...users.map(value => ({ kind: 'users' as const, value })),
+    ...(profile ? [{ kind: 'profile' as const, value: profile }] : []),
+  ]
+  if (!records.length) return []
+  const event = (payload: ArchivePayload, index: number, count: number): ArchiveEvent => ({
+    api_key: options.token, event: ARCHIVE_EVENT, uuid: randomUUID(), distinct_id: options.distinctId, timestamp: capturedAt,
+    properties: {
+      archive_schema_version: 1, request_id: requestId, captured_at: capturedAt, resource: input.resource,
+      http_status: 200, source: ['fxtwitter', 'syndication', 'contextdev', 'firecrawl', 'xsearch'].includes(input.source) ? input.source : 'unknown',
+      ...(input.cache && ['hit', 'miss', 'bypass'].includes(input.cache) ? { cache: input.cache } : {}),
+      degraded: input.degraded === true,
+      // Warnings are codes, not arbitrary provider/request text.
+      ...(input.warnings?.length ? { warnings: ['source_result_warning'] } : {}),
+      chunk_index: index, chunk_count: count, payload,
+      $process_person_profile: false, $geoip_disable: true, $ip: null,
+    },
+  })
+  const chunks: ArchivePayload[] = []
+  let current: ArchivePayload = { posts: [], users: [] }
+  const append = (payload: ArchivePayload, record: typeof records[number]): ArchivePayload => record.kind === 'profile'
+    ? { ...payload, profile: record.value as FxAuthor }
+    : { ...payload, [record.kind]: [...payload[record.kind], record.value] }
+  const fits = (payload: ArchivePayload) => Buffer.byteLength(JSON.stringify(event(payload, records.length, records.length)), 'utf8') < maxBytes
+  for (const record of records) {
+    const candidate = append(current, record)
+    if (fits(candidate)) { current = candidate; continue }
+    if (current.posts.length || current.users.length || current.profile) chunks.push(current)
+    current = append({ posts: [], users: [] }, record)
+    if (!fits(current)) throw new Error('archive_record_oversized')
+  }
+  chunks.push(current)
+  return chunks.map((payload, index) => event(payload, index, chunks.length))
+}
+
+function cookie(req: IncomingMessage, name: string): string | undefined {
+  const match = req.headers.cookie?.split(';').map(part => part.trim()).find(part => part.startsWith(`${name}=`))
+  try { return match ? decodeURIComponent(match.slice(name.length + 1)) : undefined } catch { return undefined }
+}
+export function archiveOptedOut(req: IncomingMessage): boolean {
+  return req.headers.dnt === '1' || req.headers['sec-gpc'] === '1' || req.headers['x-xmd-archive-opt-out'] === '1'
+    || cookie(req, '__Host-xmd_archive_optout') === '1'
+}
+function actorId(req: IncomingMessage, res: ServerResponse, keyId: string | undefined, secret: string, requestId: string): string {
+  if (res.getHeader('X-Api-Key-Status') === 'valid' && keyId) return `key:${createHmac('sha256', secret).update(`key:${keyId}`).digest('hex')}`
+  const actor = cookie(req, '__Host-xmd_actor')
+  if (actor && /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(actor)) {
+    return `browser:${createHmac('sha256', secret).update(`browser:${actor}`).digest('hex')}`
+  }
+  return `anonymous:${requestId}`
+}
+
+/** Best-effort delivery after a completed 200 response; not a durable queue. */
+export function captureArchive(req: IncomingMessage, res: ServerResponse, input: ArchiveInput, identity: { keyId?: string } = {}): void {
+  const token = process.env.POSTHOG_PROJECT_TOKEN || process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+  const host = process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST
+  const secret = process.env.XMD_ARCHIVE_ACTOR_SECRET
+  if (process.env.XMD_ARCHIVE_ENABLED !== 'true' || process.env.VERCEL_ENV !== 'production'
+    || !token || !host?.startsWith('https://') || !secret || secret.length < 32
+    || req.method !== 'GET' || archiveOptedOut(req)) return
+  async function send() {
+    if (res.statusCode !== 200) return
+    try {
+      const requestId = randomUUID()
+      const events = buildArchiveEvents(input, { token: token!, requestId,
+        distinctId: actorId(req, res, identity.keyId, secret!, requestId) })
+      // Sequential requests keep pressure bounded; a failed chunk stops the batch.
+      for (const event of events) {
+        const response = await fetch(`${host!.replace(/\/$/, '')}/i/v0/e/`, {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          signal: AbortSignal.timeout(3000), body: JSON.stringify(event),
+        })
+        if (!response.ok) { console.warn('[archive] PostHog rejected a chunk; archive may be incomplete'); return }
+      }
+    } catch (error) {
+      const reason = error instanceof Error && ['archive_record_oversized', 'archive_record_depth'].includes(error.message)
+        ? error.message : 'delivery_or_serialization_failed'
+      // Only fixed reason codes; no records, IDs, headers or error details.
+      console.warn(`[archive] ${reason}; archive not guaranteed`)
+    }
+  }
+  waitUntil(new Promise<void>(resolve => {
+    const onClose = () => { res.off('finish', onFinish); resolve() }
+    const onFinish = () => { res.off('close', onClose); void send().finally(resolve) }
+    res.once('finish', onFinish)
+    res.once('close', onClose)
+  }))
+}

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -185,6 +185,8 @@ export function captureArchive(req: IncomingMessage, res: ServerResponse, input:
       for (const event of events) {
         const response = await fetch(`${host!.replace(/\/$/, '')}/i/v0/e/`, {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
+          // Never replay content or the project token to a redirect target.
+          redirect: 'error',
           signal: AbortSignal.timeout(3000), body: JSON.stringify(event),
         })
         if (!response.ok) { console.warn('[archive] PostHog rejected a chunk; archive may be incomplete'); return }

--- a/lib/fixtures/archive-v1-full.json
+++ b/lib/fixtures/archive-v1-full.json
@@ -1,0 +1,106 @@
+[
+  {
+    "api_key": "phc_fixture_not_a_real_token",
+    "event": "xmd_data_captured",
+    "uuid": "4af73e25-a9bd-4721-bb19-93f6695b7b8d",
+    "distinct_id": "anonymous:00000000-0000-4000-8000-000000000002",
+    "timestamp": "2026-09-07T00:00:00.000Z",
+    "properties": {
+      "archive_schema_version": 1,
+      "request_id": "00000000-0000-4000-8000-000000000002",
+      "captured_at": "2026-09-07T00:00:00.000Z",
+      "resource": "tweet",
+      "http_status": 200,
+      "source": "fxtwitter",
+      "cache": "miss",
+      "degraded": false,
+      "chunk_index": 0,
+      "chunk_count": 1,
+      "payload": {
+        "posts": [
+          {
+            "id": "1234567890123456789",
+            "text": "Public fixture post with photo and quote",
+            "created_at": "Mon Sep 07 00:00:00 +0000 2026",
+            "lang": "en",
+            "url": "https://x.com/example/status/1234567890123456789",
+            "created_timestamp": 1788739200,
+            "replies": 1,
+            "retweets": 2,
+            "likes": 10,
+            "views": 500,
+            "bookmarks": 2,
+            "quotes": 1,
+            "possibly_sensitive": false,
+            "media": {
+              "photos": [
+                {
+                  "type": "photo",
+                  "alt": "Example photo",
+                  "url": "https://pbs.twimg.com/media/example.jpg",
+                  "width": 1200,
+                  "height": 800
+                }
+              ]
+            },
+            "author": {
+              "id": "12345",
+              "name": "Example",
+              "screen_name": "example",
+              "description": "Public example profile",
+              "joined": "Mon Jan 01 00:00:00 +0000 2024",
+              "url": "https://x.com/example",
+              "avatar_url": "https://pbs.twimg.com/profile_images/example.jpg",
+              "followers": 120,
+              "following": 25,
+              "likes": 50,
+              "media_count": 3,
+              "statuses": 30,
+              "protected": false,
+              "verification": {
+                "verified": false,
+                "type": "none"
+              }
+            },
+            "quote": {
+              "id": "1234567890123456788",
+              "text": "A public quoted post",
+              "created_at": "Sun Sep 06 00:00:00 +0000 2026",
+              "lang": "en",
+              "url": "https://x.com/quoted/status/1234567890123456788",
+              "created_timestamp": 1788652800,
+              "replies": 0,
+              "retweets": 1,
+              "likes": 5,
+              "views": 100,
+              "bookmarks": 0,
+              "quotes": 1,
+              "possibly_sensitive": false,
+              "author": {
+                "id": "54321",
+                "name": "Quoted Author",
+                "screen_name": "quoted",
+                "description": "Another public profile",
+                "joined": "Mon Jan 01 00:00:00 +0000 2024",
+                "avatar_url": "https://pbs.twimg.com/profile_images/quoted.jpg",
+                "followers": 55,
+                "following": 15,
+                "likes": 12,
+                "media_count": 0,
+                "statuses": 100,
+                "protected": false,
+                "verification": {
+                  "verified": false
+                }
+              }
+            }
+          }
+        ],
+        "users": []
+      },
+      "$process_person_profile": false,
+      "$geoip_disable": true,
+      "$ip": null
+    }
+  }
+]

--- a/lib/fixtures/archive-v1-incomplete.json
+++ b/lib/fixtures/archive-v1-incomplete.json
@@ -1,0 +1,44 @@
+[
+  {
+    "api_key": "phc_fixture_not_a_real_token",
+    "event": "xmd_data_captured",
+    "uuid": "17581b79-f1b5-4f0d-b457-6f1b1e3a9184",
+    "distinct_id": "anonymous:00000000-0000-4000-8000-000000000001",
+    "timestamp": "2026-09-07T00:00:00.000Z",
+    "properties": {
+      "archive_schema_version": 1,
+      "request_id": "00000000-0000-4000-8000-000000000001",
+      "captured_at": "2026-09-07T00:00:00.000Z",
+      "resource": "profile",
+      "http_status": 200,
+      "source": "fxtwitter",
+      "cache": "hit",
+      "degraded": false,
+      "chunk_index": 0,
+      "chunk_count": 1,
+      "payload": {
+        "posts": [
+          {
+            "id": "1234567890123456789",
+            "text": "Public fixture post",
+            "created_at": "2026-09-07T00:00:00.000Z",
+            "author": {
+              "id": "12345",
+              "name": "Example",
+              "screen_name": "example"
+            }
+          }
+        ],
+        "users": [],
+        "profile": {
+          "id": "12345",
+          "name": "Example",
+          "screen_name": "example"
+        }
+      },
+      "$process_person_profile": false,
+      "$geoip_disable": true,
+      "$ip": null
+    }
+  }
+]

--- a/lib/fixtures/archive-v1.json
+++ b/lib/fixtures/archive-v1.json
@@ -1,0 +1,106 @@
+[
+  {
+    "api_key": "phc_fixture_not_a_real_token",
+    "event": "xmd_data_captured",
+    "uuid": "4af73e25-a9bd-4721-bb19-93f6695b7b8d",
+    "distinct_id": "anonymous:00000000-0000-4000-8000-000000000002",
+    "timestamp": "2026-09-07T00:00:00.000Z",
+    "properties": {
+      "archive_schema_version": 1,
+      "request_id": "00000000-0000-4000-8000-000000000002",
+      "captured_at": "2026-09-07T00:00:00.000Z",
+      "resource": "tweet",
+      "http_status": 200,
+      "source": "fxtwitter",
+      "cache": "miss",
+      "degraded": false,
+      "chunk_index": 0,
+      "chunk_count": 1,
+      "payload": {
+        "posts": [
+          {
+            "id": "1234567890123456789",
+            "text": "Public fixture post with photo and quote",
+            "created_at": "Mon Sep 07 00:00:00 +0000 2026",
+            "lang": "en",
+            "url": "https://x.com/example/status/1234567890123456789",
+            "created_timestamp": 1788739200,
+            "replies": 1,
+            "retweets": 2,
+            "likes": 10,
+            "views": 500,
+            "bookmarks": 2,
+            "quotes": 1,
+            "possibly_sensitive": false,
+            "media": {
+              "photos": [
+                {
+                  "type": "photo",
+                  "alt": "Example photo",
+                  "url": "https://pbs.twimg.com/media/example.jpg",
+                  "width": 1200,
+                  "height": 800
+                }
+              ]
+            },
+            "author": {
+              "id": "12345",
+              "name": "Example",
+              "screen_name": "example",
+              "description": "Public example profile",
+              "joined": "Mon Jan 01 00:00:00 +0000 2024",
+              "url": "https://x.com/example",
+              "avatar_url": "https://pbs.twimg.com/profile_images/example.jpg",
+              "followers": 120,
+              "following": 25,
+              "likes": 50,
+              "media_count": 3,
+              "statuses": 30,
+              "protected": false,
+              "verification": {
+                "verified": false,
+                "type": "none"
+              }
+            },
+            "quote": {
+              "id": "1234567890123456788",
+              "text": "A public quoted post",
+              "created_at": "Sun Sep 06 00:00:00 +0000 2026",
+              "lang": "en",
+              "url": "https://x.com/quoted/status/1234567890123456788",
+              "created_timestamp": 1788652800,
+              "replies": 0,
+              "retweets": 1,
+              "likes": 5,
+              "views": 100,
+              "bookmarks": 0,
+              "quotes": 1,
+              "possibly_sensitive": false,
+              "author": {
+                "id": "54321",
+                "name": "Quoted Author",
+                "screen_name": "quoted",
+                "description": "Another public profile",
+                "joined": "Mon Jan 01 00:00:00 +0000 2024",
+                "avatar_url": "https://pbs.twimg.com/profile_images/quoted.jpg",
+                "followers": 55,
+                "following": 15,
+                "likes": 12,
+                "media_count": 0,
+                "statuses": 100,
+                "protected": false,
+                "verification": {
+                  "verified": false
+                }
+              }
+            }
+          }
+        ],
+        "users": []
+      },
+      "$process_person_profile": false,
+      "$geoip_disable": true,
+      "$ip": null
+    }
+  }
+]

--- a/src/posthog.test.ts
+++ b/src/posthog.test.ts
@@ -1,17 +1,40 @@
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import posthog from 'posthog-js'
 
-vi.mock('posthog-js', () => ({ default: { init: vi.fn(), capture: vi.fn() } }))
+vi.mock('posthog-js', () => ({ default: {
+  init: vi.fn(), capture: vi.fn(), get_distinct_id: vi.fn(),
+  get_property: vi.fn(), has_opted_out_capturing: vi.fn(),
+} }))
+
+const actorId = '019abcde-1234-7123-8123-123456789abc'
+let cookies: Map<string, string>
+let cookieWrites: string[]
 
 beforeEach(() => {
   vi.resetModules()
   vi.mocked(posthog.init).mockReset()
   vi.mocked(posthog.capture).mockReset()
+  vi.mocked(posthog.get_distinct_id).mockReset().mockReturnValue(actorId)
+  vi.mocked(posthog.get_property).mockReset().mockReturnValue(undefined)
+  vi.mocked(posthog.has_opted_out_capturing).mockReset().mockReturnValue(false)
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', '')
+  vi.stubGlobal('navigator', { doNotTrack: '0', globalPrivacyControl: false })
+  cookies = new Map()
+  cookieWrites = []
+  vi.stubGlobal('document', {
+    get cookie() { return [...cookies].map(([name, value]) => `${name}=${value}`).join('; ') },
+    set cookie(value: string) {
+      cookieWrites.push(value)
+      const [name, content] = value.split(';')[0].split('=')
+      if (value.includes('Max-Age=0')) cookies.delete(name)
+      else cookies.set(name, content)
+    },
+  })
   vi.stubEnv('PROD', true)
   vi.stubEnv('VERCEL_ENV', 'production')
   vi.stubEnv('VITE_POSTHOG_KEY', 'phc_test')
   vi.stubEnv('VITE_POSTHOG_HOST', 'https://p.pcstyle.dev')
-  vi.stubGlobal('window', { location: { pathname: '/', origin: 'https://x.pcstyle.dev', host: 'x.pcstyle.dev', href: 'https://x.pcstyle.dev/?secret=private-value' } })
+  vi.stubGlobal('window', { location: { protocol: 'https:', pathname: '/', origin: 'https://x.pcstyle.dev', host: 'x.pcstyle.dev', href: 'https://x.pcstyle.dev/?secret=private-value' } })
 })
 
 afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals() })
@@ -75,4 +98,140 @@ test('analytics failures do not interrupt loading or interactions', async () => 
   const enabled = await import('./posthog')
   vi.mocked(posthog.capture).mockImplementation(() => { throw new Error('blocked') })
   expect(() => enabled.captureLandingEvent('conversion_requested')).not.toThrow()
+})
+
+function loaded() {
+  const options = vi.mocked(posthog.init).mock.calls[0][1]!
+  options.loaded!(posthog)
+}
+
+test('bridge is disabled by default without changing ordinary analytics', async () => {
+  const { captureLandingEvent } = await import('./posthog')
+  loaded()
+  captureLandingEvent('conversion_requested')
+  expect(cookieWrites).toEqual([])
+  expect(posthog.get_distinct_id).not.toHaveBeenCalled()
+})
+
+test('bridges anonymous identity on loaded and refreshes it before conversion', async () => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  const { captureLandingEvent } = await import('./posthog')
+  loaded()
+  expect(cookieWrites).toEqual([`__Host-xmd_actor=${encodeURIComponent(actorId)}; Secure; SameSite=Lax; Path=/; Max-Age=2592000`])
+  const freshId = '019abcde-1234-7123-8123-123456789abd'
+  vi.mocked(posthog.get_distinct_id).mockReturnValue(freshId)
+  vi.mocked(posthog.capture).mockImplementation(() => {
+    expect(cookies.get('__Host-xmd_actor')).toBe(freshId)
+    return undefined
+  })
+  captureLandingEvent('conversion_requested')
+  expect(posthog.capture).toHaveBeenCalledWith('conversion_requested')
+  expect(window.location.href).not.toContain(actorId)
+})
+
+test.each(['false', 'TRUE', '1'])('requires exact bridge flag: %s', async value => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', value)
+  await import('./posthog')
+  loaded()
+  expect(cookieWrites).toEqual([])
+})
+
+test('never writes bridge cookies on HTTP', async () => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  window.location.protocol = 'http:'
+  const { captureLandingEvent } = await import('./posthog')
+  loaded()
+  captureLandingEvent('conversion_requested')
+  expect(cookieWrites).toEqual([])
+})
+
+test.each(['email@example.com', 'user-123', '', '019abcde-1234-7123-8123-123456789abc;other=1'])('clears non-anonymous ID %s', async id => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  cookies.set('__Host-xmd_actor', actorId)
+  vi.mocked(posthog.get_distinct_id).mockReturnValue(id)
+  await import('./posthog')
+  loaded()
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+})
+
+test.each([['$user_id', actorId], ['$is_identified', true], ['$user_state', 'identified']] as const)('does not bridge identified UUID (%s)', async (property, value) => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  cookies.set('__Host-xmd_actor', actorId)
+  vi.mocked(posthog.get_property).mockImplementation(key => key === property ? value : undefined)
+  await import('./posthog')
+  loaded()
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+})
+
+function blockPrivacy(signal: string) {
+  if (signal === 'cookie') cookies.set('__Host-xmd_archive_optout', '1')
+  else if (signal === 'DNT') vi.stubGlobal('navigator', { doNotTrack: '1' })
+  else vi.stubGlobal('navigator', { globalPrivacyControl: true })
+}
+
+test.each(['cookie', 'DNT', 'GPC'])('honors %s before initialization and removes stale actor', async signal => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  cookies.set('__Host-xmd_actor', actorId)
+  blockPrivacy(signal)
+  const { captureLandingEvent } = await import('./posthog')
+  captureLandingEvent('conversion_requested')
+  expect(posthog.init).not.toHaveBeenCalled()
+  expect(posthog.capture).not.toHaveBeenCalled()
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+})
+
+test.each(['cookie', 'DNT', 'GPC'])('honors new %s before conversion', async signal => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  const { captureLandingEvent } = await import('./posthog')
+  loaded()
+  blockPrivacy(signal)
+  captureLandingEvent('conversion_requested')
+  expect(posthog.capture).not.toHaveBeenCalled()
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+})
+
+test('SDK opt-out clears actor before conversion', async () => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  const { captureLandingEvent } = await import('./posthog')
+  loaded()
+  vi.mocked(posthog.has_opted_out_capturing).mockReturnValue(true)
+  captureLandingEvent('conversion_requested')
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+  expect(cookieWrites.at(-1)).toBe('__Host-xmd_actor=; Secure; SameSite=Lax; Path=/; Max-Age=0')
+  expect(cookieWrites).toContain('__Host-xmd_archive_optout=1; Secure; SameSite=Lax; Path=/; Max-Age=2592000')
+  vi.mocked(posthog.has_opted_out_capturing).mockReturnValue(false)
+  captureLandingEvent('conversion_requested')
+  expect(cookies.get('__Host-xmd_archive_optout')).toBe('1')
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+})
+
+test('SDK bridge failures clear stale identity without breaking conversion', async () => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  const { captureLandingEvent } = await import('./posthog')
+  loaded()
+  vi.mocked(posthog.get_distinct_id).mockImplementation(() => { throw new Error('blocked') })
+  expect(() => captureLandingEvent('conversion_requested')).not.toThrow()
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+  expect(posthog.capture).toHaveBeenCalledWith('conversion_requested')
+})
+
+
+test.each(['cookie', 'DNT', 'GPC'])('before_send honors new %s for automatic events', async signal => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  await import('./posthog')
+  loaded()
+  const beforeSend = vi.mocked(posthog.init).mock.calls[0][1]!.before_send as (event: any) => any
+  blockPrivacy(signal)
+  expect(beforeSend({ event: '$pageview', properties: {} })).toBeNull()
+  expect(beforeSend({ event: '$pageleave', properties: {} })).toBeNull()
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+})
+
+test('mirrors existing SDK optout when the SDK loads', async () => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  vi.mocked(posthog.has_opted_out_capturing).mockReturnValue(true)
+  await import('./posthog')
+  loaded()
+  expect(cookies.get('__Host-xmd_archive_optout')).toBe('1')
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
 })

--- a/src/posthog.test.ts
+++ b/src/posthog.test.ts
@@ -109,7 +109,8 @@ test('bridge is disabled by default without changing ordinary analytics', async 
   const { captureLandingEvent } = await import('./posthog')
   loaded()
   captureLandingEvent('conversion_requested')
-  expect(cookieWrites).toEqual([])
+  expect(cookieWrites.length).toBeGreaterThan(0)
+  expect(cookieWrites.every(cookie => cookie.includes('Max-Age=0'))).toBe(true)
   expect(posthog.get_distinct_id).not.toHaveBeenCalled()
 })
 
@@ -133,7 +134,8 @@ test.each(['false', 'TRUE', '1'])('requires exact bridge flag: %s', async value 
   vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', value)
   await import('./posthog')
   loaded()
-  expect(cookieWrites).toEqual([])
+  expect(cookieWrites.length).toBeGreaterThan(0)
+  expect(cookieWrites.every(cookie => cookie.includes('Max-Age=0'))).toBe(true)
 })
 
 test('never writes bridge cookies on HTTP', async () => {
@@ -234,4 +236,22 @@ test('mirrors existing SDK optout when the SDK loads', async () => {
   loaded()
   expect(cookies.get('__Host-xmd_archive_optout')).toBe('1')
   expect(cookies.has('__Host-xmd_actor')).toBe(false)
+})
+
+
+test.each([true, false])('disabling an enabled bridge clears its actor even with SDK available=%s', async sdkAvailable => {
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'true')
+  await import('./posthog')
+  loaded()
+  expect(cookies.get('__Host-xmd_actor')).toBe(actorId)
+  vi.resetModules()
+  vi.mocked(posthog.init).mockClear()
+  vi.mocked(posthog.get_distinct_id).mockClear()
+  vi.stubEnv('VITE_XMD_ARCHIVE_ACTOR_BRIDGE', 'false')
+  if (!sdkAvailable) vi.stubEnv('VITE_POSTHOG_KEY', '')
+  await import('./posthog')
+  expect(cookies.has('__Host-xmd_actor')).toBe(false)
+  expect(cookieWrites.at(-1)).toBe('__Host-xmd_actor=; Secure; SameSite=Lax; Path=/; Max-Age=0')
+  expect(posthog.get_distinct_id).not.toHaveBeenCalled()
+  if (!sdkAvailable) expect(posthog.init).not.toHaveBeenCalled()
 })

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -3,6 +3,53 @@ import posthog from 'posthog-js'
 const posthogKey = import.meta.env.VITE_POSTHOG_KEY
 const posthogHost = import.meta.env.VITE_POSTHOG_HOST
 let enabled = false
+const actorBridgeEnabled = import.meta.env.VITE_XMD_ARCHIVE_ACTOR_BRIDGE === 'true'
+const actorCookie = '__Host-xmd_actor'
+const anonymousId = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+function privacyBlocked() {
+  const browser = navigator as Navigator & { globalPrivacyControl?: boolean }
+  return browser.doNotTrack === '1' || browser.doNotTrack === 'yes'
+    || browser.globalPrivacyControl === true
+    || document.cookie.split(';').some(cookie => cookie.trim() === '__Host-xmd_archive_optout=1')
+}
+
+function clearActor() {
+  if (window.location.protocol === 'https:') {
+    document.cookie = `${actorCookie}=; Secure; SameSite=Lax; Path=/; Max-Age=0`
+  }
+}
+
+function bridgeActor() {
+  if (!actorBridgeEnabled || window.location.protocol !== 'https:') return
+  try {
+    if (posthog.has_opted_out_capturing()) {
+      document.cookie = '__Host-xmd_archive_optout=1; Secure; SameSite=Lax; Path=/; Max-Age=2592000'
+      clearActor()
+      return
+    }
+    const id = posthog.get_distinct_id()
+    // Identified IDs can also look like UUIDs. Check persisted identity state too.
+    if (privacyBlocked()
+      || posthog.get_property('$user_id') != null
+      || posthog.get_property('$is_identified') === true
+      || posthog.get_property('$user_state') === 'identified'
+      || typeof id !== 'string' || !anonymousId.test(id)) {
+      clearActor()
+      return
+    }
+    document.cookie = `${actorCookie}=${encodeURIComponent(id)}; Secure; SameSite=Lax; Path=/; Max-Age=2592000`
+  } catch {
+    // Storage or SDK access can fail. Never keep a stale identity in that case.
+    try { clearActor() } catch { /* Cookies may be blocked. */ }
+  }
+}
+
+let blocked = true
+try {
+  blocked = privacyBlocked()
+  if (blocked) clearActor()
+} catch { /* Fail closed when privacy settings cannot be read. */ }
 
 const events = new Set(['$pageview', '$pageleave', 'conversion_requested', 'skill_install_command_copied'])
 const properties = new Set([
@@ -13,10 +60,11 @@ const properties = new Set([
   '$prev_pageview_id', '$prev_pageview_duration',
 ])
 
-if (import.meta.env.PROD && import.meta.env.VERCEL_ENV === 'production' && posthogKey && posthogHost?.startsWith('https://') && window.location.pathname === '/') {
+if (!blocked && import.meta.env.PROD && import.meta.env.VERCEL_ENV === 'production' && posthogKey && posthogHost?.startsWith('https://') && window.location.pathname === '/') {
   try {
     posthog.init(posthogKey, {
       api_host: posthogHost,
+      loaded: () => bridgeActor(),
       ui_host: 'https://eu.posthog.com',
       defaults: '2026-05-30',
       persistence: 'localStorage',
@@ -30,6 +78,9 @@ if (import.meta.env.PROD && import.meta.env.VERCEL_ENV === 'production' && posth
       disable_surveys: true,
       enable_heatmaps: false,
       before_send(event) {
+        try {
+          if (privacyBlocked()) { clearActor(); return null }
+        } catch { return null }
         if (!event || !events.has(event.event) || window.location.pathname !== '/') return null
         // Keep session/browser metrics, not SDK-enriched URLs, referrers or user data.
         event.properties = Object.fromEntries(Object.entries(event.properties).filter(([key]) => properties.has(key)))
@@ -56,5 +107,9 @@ if (import.meta.env.PROD && import.meta.env.VERCEL_ENV === 'production' && posth
 
 export function captureLandingEvent(event: 'conversion_requested' | 'skill_install_command_copied') {
   if (!enabled || window.location.pathname !== '/' || !events.has(event)) return
-  try { posthog.capture(event) } catch { /* Keep the interaction working if analytics fails. */ }
+  try {
+    if (privacyBlocked()) { clearActor(); return }
+    if (event === 'conversion_requested') bridgeActor()
+    posthog.capture(event)
+  } catch { /* Keep the interaction working if analytics fails. */ }
 }

--- a/src/posthog.ts
+++ b/src/posthog.ts
@@ -21,8 +21,9 @@ function clearActor() {
 }
 
 function bridgeActor() {
-  if (!actorBridgeEnabled || window.location.protocol !== 'https:') return
+  if (window.location.protocol !== 'https:') return
   try {
+    if (!actorBridgeEnabled) { clearActor(); return }
     if (posthog.has_opted_out_capturing()) {
       document.cookie = '__Host-xmd_archive_optout=1; Secure; SameSite=Lax; Path=/; Max-Age=2592000'
       clearActor()
@@ -47,6 +48,9 @@ function bridgeActor() {
 
 let blocked = true
 try {
+  // A previous enabled build may have left an actor cookie behind. Clean up
+  // even when configuration prevents the SDK from initializing.
+  if (!actorBridgeEnabled) clearActor()
   blocked = privacyBlocked()
   if (blocked) clearActor()
 } catch { /* Fail closed when privacy settings cannot be read. */ }


### PR DESCRIPTION
## Problem
Successful public results cannot currently feed a dataset archive without scraping responses again.

## Changes
- Add disabled-by-default production PostHog content capture after successful GET responses, including application-cache hits.
- Allowlist public fields, chunk events below 190 KB, exclude protected records and sensitive request data, and honor archive opt-outs.
- Add optional anonymous browser actor bridge, HMAC actor IDs, export fixtures, and operator/privacy documentation.
- No manual deployment or production enablement.

## Validation
- `bun --bun tsc` passed.
- `bun run test` passed: 268 tests across 20 files.
- `bun run build` passed (existing Vite import/chunk warnings).
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional, disabled-by-default archive for structured public results from successful production browse and convert requests.
  - Archived data is privacy-filtered, pseudonymized, size-limited, and excludes protected information.
  - Added opt-out support through privacy signals and cookies.

- **Documentation**
  - Added configuration guidance and an archive policy covering data handling, retention, delivery limits, and actor association.
  - Updated self-hosting documentation with details about the optional archive and related privacy behavior.

- **Tests**
  - Added coverage for archive filtering, privacy controls, delivery behavior, and actor-cookie handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->