### PR TITLE
feat: emit server-side PostHog events at the API call sites

### DIFF
--- a/api/browse.ts
+++ b/api/browse.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { trackRequest } from '../lib/analytics.js'
+import { captureBatchBrowse, trackRequest } from '../lib/analytics.js'
 import { problemDetails, problemFrom, requestInstance, sendProblem, setDeprecationHeaders } from '../lib/apierror.js'
 import { captureArchive } from '../lib/archive.js'
 import { callerHeaders, resolveCaller } from '../lib/apiauth.js'
@@ -94,6 +94,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     for (const [key, header] of Object.entries(response.headers)) res.setHeader(key, header)
     // Keyed responses stay private even if the browse layer marked them cacheable.
     for (const [key, value] of Object.entries(callerHeaders(resolved))) res.setHeader(key, value)
+    if ((req.url ?? '').split('?')[0] === '/api/browse' && param('via') !== 'route') {
+      captureBatchBrowse({
+        resource: result.resource,
+        format: wantsJson(param('format'), accept) ? 'json' : 'markdown',
+        resultCount: result.posts?.length ?? result.users?.length ?? 0,
+        hasCursor: Boolean(param('cursor')),
+      })
+    }
     if (response.status === 200) captureArchive(req, res, result, identity)
     return req.method === 'HEAD' ? res.status(response.status).end() : res.status(response.status).send(response.body)
   } catch (error) {

--- a/api/oembed.ts
+++ b/api/oembed.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
-import { trackRequest } from '../lib/analytics.js'
+import { captureOEmbedRequested, trackRequest } from '../lib/analytics.js'
 import { problemDetails, problemFrom, requestInstance, sendProblem } from '../lib/apierror.js'
 import { oembedResponse } from '../lib/embed.js'
 import { requestOrigin, setCorsHeaders } from '../lib/http.js'
@@ -32,6 +32,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     )
   }
 
+  const param = (key: string): string | undefined => (typeof req.query[key] === 'string' ? req.query[key] : undefined)
+  captureOEmbedRequested(String(req.headers['user-agent'] ?? ''), param('format'))
+
   // Charged before anything can return, so every response carries the caller's
   // remaining allowance, not just a 429.
   const quota = await chargeRequestQuota('read', caller)
@@ -50,7 +53,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     )
   }
 
-  const param = (key: string): string | undefined => (typeof req.query[key] === 'string' ? req.query[key] : undefined)
   try {
     const { status, headers, body } = oembedResponse(
       {

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -2,23 +2,38 @@ import { IncomingMessage, ServerResponse } from 'node:http'
 import { Socket } from 'node:net'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { waitUntil } from '@vercel/functions'
-import { trackRequest } from './analytics.js'
+import {
+  captureBatchBrowse,
+  captureCacheLookup,
+  captureFallback,
+  captureMediaResolved,
+  captureOEmbedRequested,
+  captureRateLimit,
+  captureSearchExecuted,
+  captureUpstreamError,
+  errorTypeFor,
+  trackRequest,
+} from './analytics.js'
 
 vi.mock('@vercel/functions', () => ({ waitUntil: vi.fn() }))
 
 const fetchMock = vi.fn()
-function request(method = 'GET') {
+function request(method = 'GET', url = '/search?q=private-search') {
   const req = new IncomingMessage(new Socket())
   req.method = method
-  req.url = '/search?q=private-search'
+  req.url = url
   req.headers = { authorization: 'Bearer private-token', 'x-real-ip': '192.0.2.55' }
   return { req, res: new ServerResponse(req) }
+}
+async function sent() {
+  await Promise.all(vi.mocked(waitUntil).mock.calls.map(call => call[0]).filter(Boolean))
+  return fetchMock.mock.calls.map(call => JSON.parse(call[1].body as string))
 }
 async function finish(res: ServerResponse) {
   res.emit('finish')
   res.emit('close')
-  await vi.mocked(waitUntil).mock.calls.at(-1)?.[0]
-  return JSON.parse(fetchMock.mock.calls.at(-1)![1].body)
+  const events = await sent()
+  return events.findLast(event => event.event === 'request_completed') ?? events.at(-1)
 }
 
 beforeEach(() => {
@@ -38,18 +53,18 @@ afterEach(() => {
 })
 
 describe('production request analytics', () => {
-  test('sends one allowlisted event after completion, without request details', async () => {
+  test('sends allowlisted events after completion, without request details', async () => {
     const { req, res } = request()
     const timeout = vi.spyOn(AbortSignal, 'timeout')
     trackRequest(req, res, 'browse', 'search')
-    expect(waitUntil).toHaveBeenCalledOnce()
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(waitUntil).toHaveBeenCalledTimes(2)
+    await vi.mocked(waitUntil).mock.calls[0][0]
+    expect(fetchMock.mock.calls.map(call => JSON.parse(call[1].body as string).event)).toEqual(['endpoint_called'])
     res.statusCode = 429
     res.setHeader('X-Cache', 'BYPASS')
     res.setHeader('X-Search-Degraded', 'true')
     const event = await finish(res)
     res.emit('finish')
-    expect(fetchMock).toHaveBeenCalledOnce()
     expect(fetchMock.mock.calls[0][0]).toBe('https://eu.i.posthog.com/i/v0/e/')
     expect(timeout).toHaveBeenCalledWith(3000)
     expect(event.event).toBe('request_completed')
@@ -58,7 +73,12 @@ describe('production request analytics', () => {
       cache: 'bypass', access: 'public', key_status: 'anonymous', degraded: true,
       environment: 'production', $process_person_profile: false, $geoip_disable: true, $ip: null,
     })
-    const serialized = JSON.stringify(event)
+    const events = await sent()
+    expect(events.map(item => item.event).sort()).toEqual(['endpoint_called', 'request_completed', 'request_failed'])
+    expect(events.find(item => item.event === 'request_failed').properties).toMatchObject({
+      route: 'search', status: 429, error_type: 'rate_limited', duration_ms: expect.any(Number), environment: 'production',
+    })
+    const serialized = JSON.stringify(events)
     for (const secret of ['private-search', 'private-token', '192.0.2.55']) expect(serialized).not.toContain(secret)
   })
 
@@ -78,7 +98,7 @@ describe('production request analytics', () => {
     expect(waitUntil).not.toHaveBeenCalled()
   })
 
-  test('ignores preflights and disconnected requests', async () => {
+  test('ignores preflights and does not complete disconnected requests', async () => {
     const preflight = request('OPTIONS')
     trackRequest(preflight.req, preflight.res, 'browse')
     expect(waitUntil).not.toHaveBeenCalled()
@@ -86,8 +106,8 @@ describe('production request analytics', () => {
     trackRequest(req, res, 'browse')
     res.emit('close')
     res.emit('finish')
-    await vi.mocked(waitUntil).mock.calls[0][0]
-    expect(fetchMock).not.toHaveBeenCalled()
+    const events = await sent()
+    expect(events.map(event => event.event)).toEqual(['endpoint_called'])
     expect(res.listenerCount('finish')).toBe(0)
   })
 
@@ -132,7 +152,97 @@ describe('production request analytics', () => {
     res.statusCode = 200
     await finish(res)
     expect(res.statusCode).toBe(200)
-    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalled()
     expect(JSON.stringify(warn.mock.calls)).not.toContain('private-detail')
+  })
+})
+
+describe('named server events', () => {
+  test('endpoint_called classifies permalink convert vs generic convert', async () => {
+    const permalink = request('GET', '/api/convert?handle=alice&id=20&via=route&format=json&full=true&thread=off&replies=recent&nocache=true')
+    trackRequest(permalink.req, permalink.res, 'convert')
+    const generic = request('GET', '/api/convert?url=https://x.com/alice/status/20')
+    trackRequest(generic.req, generic.res, 'convert')
+    permalink.res.emit('finish'); permalink.res.emit('close')
+    generic.res.emit('finish'); generic.res.emit('close')
+    const events = (await sent()).filter(event => event.event === 'endpoint_called')
+    expect(events[0].properties).toMatchObject({
+      endpoint: 'status_convert', format: 'json', full: true, thread: 'off', replies: 'recent', nocache: true, has_handle: true, environment: 'production',
+    })
+    expect(events[1].properties).toMatchObject({
+      endpoint: 'generic_convert', format: 'markdown', full: false, thread: 'full', replies: 'top', nocache: false, has_handle: false,
+    })
+    expect(JSON.stringify(events)).not.toContain('alice')
+  })
+
+  test('endpoint_called names browse resources and the aggregate alias', async () => {
+    const search = request('GET', '/search?q=hello')
+    trackRequest(search.req, search.res, 'browse', 'search')
+    const followers = request('GET', '/api/browse?resource=followers&handle=alice')
+    trackRequest(followers.req, followers.res, 'browse', 'followers')
+    search.res.emit('finish'); search.res.emit('close')
+    followers.res.emit('finish'); followers.res.emit('close')
+    const events = (await sent()).filter(event => event.event === 'endpoint_called')
+    expect(events[0].properties.endpoint).toBe('search_browse')
+    expect(events[1].properties.endpoint).toBe('api_browse')
+    expect(events[1].properties.has_handle).toBe(true)
+    expect(JSON.stringify(events)).not.toContain('alice')
+  })
+
+  test('request_failed maps catalog codes onto coarse error types', () => {
+    expect(errorTypeFor('not_found', 404)).toBe('not_found')
+    expect(errorTypeFor('invalid_url', 400)).toBe('validation_error')
+    expect(errorTypeFor('invalid_body', 400)).toBe('parse_error')
+    expect(errorTypeFor('rate_limited', 429)).toBe('rate_limited')
+    expect(errorTypeFor('fxtwitter_error', 502)).toBe('upstream_error')
+    expect(errorTypeFor(undefined, 500)).toBe('upstream_error')
+  })
+
+  test('helper events stay structural and drop media URLs', async () => {
+    const { req, res } = request('GET', '/alice/status/20')
+    trackRequest(req, res, 'convert')
+    captureCacheLookup('hit', 'status')
+    captureCacheLookup('miss', 'profile')
+    captureCacheLookup('bypass', 'search')
+    captureUpstreamError({ provider: 'fxtwitter', errorType: 'timeout', upstreamStatus: null, durationMs: 12.4 })
+    captureFallback({ primaryProvider: 'fxtwitter', fallbackProvider: 'syndication', reason: 'primary_timeout' })
+    captureRateLimit('ip')
+    captureSearchExecuted({ feedType: 'latest', hasQuery: true, resultCount: 3 })
+    captureBatchBrowse({ resource: 'search', format: 'json', resultCount: 3, hasCursor: true })
+    captureOEmbedRequested('Mozilla/5.0 (compatible; Discordbot/2.0)', 'json')
+    captureMediaResolved([{
+      media: {
+        videos: [{ url: 'https://video.twimg.com/private-clip.mp4', variants: [{}, {}] }],
+        photos: [{ }],
+      },
+    }])
+    await finish(res)
+    const events = await sent()
+    const byName = Object.fromEntries(events.map(event => [event.event, event.properties]))
+    expect(byName.cache_hit).toMatchObject({ route: 'convert', endpoint: 'generic_convert', cache_key_type: 'status', environment: 'production' })
+    expect(byName.cache_miss).toMatchObject({ cache_key_type: 'profile' })
+    expect(byName.cache_hit && byName.cache_miss).toBeTruthy()
+    expect(events.some(event => event.event === 'cache_bypass')).toBe(false)
+    expect(byName.upstream_error).toMatchObject({
+      provider: 'fxtwitter', error_type: 'timeout', upstream_status: null, duration_ms: 12, route: 'convert',
+    })
+    expect(byName.fallback_used).toMatchObject({
+      primary_provider: 'fxtwitter', fallback_provider: 'syndication', reason: 'primary_timeout', route: 'convert',
+    })
+    expect(byName.rate_limit_applied).toMatchObject({ limit_type: 'ip', route: 'convert' })
+    expect(byName.search_executed).toMatchObject({ feed_type: 'latest', has_query: true, result_count: 3 })
+    expect(byName.batch_browse_called).toMatchObject({ resource: 'search', format: 'json', result_count: 3, has_cursor: true })
+    expect(byName.oEmbed_requested).toMatchObject({ requester_bot: 'Discordbot', format: 'json' })
+    expect(byName.media_resolved).toMatchObject({
+      media_type: 'mixed', variant_count: 2, has_direct_url: true, route: 'convert',
+    })
+    expect(JSON.stringify(events)).not.toContain('private-clip')
+    expect(JSON.stringify(events)).not.toContain('twimg.com')
+  })
+
+  test('oEmbed requester_bot is null for ordinary clients', async () => {
+    captureOEmbedRequested('Mozilla/5.0', 'xml')
+    const events = await sent()
+    expect(events.at(-1).properties).toMatchObject({ requester_bot: null, format: 'xml', environment: 'production' })
   })
 })

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -175,6 +175,16 @@ describe('named server events', () => {
     expect(JSON.stringify(events)).not.toContain('alice')
   })
 
+  test('endpoint_called does not copy unbounded numeric thread values', async () => {
+    const { req, res } = request('GET', '/api/convert?handle=alice&id=20&thread=1848330199730315645')
+    trackRequest(req, res, 'convert')
+    res.emit('finish'); res.emit('close')
+    const event = (await sent()).find(item => item.event === 'endpoint_called')
+    expect(event.properties.thread).toBe('full')
+    expect(JSON.stringify(event)).not.toContain('1848330199730315645')
+    expect(JSON.stringify(event)).not.toContain('alice')
+  })
+
   test('endpoint_called names browse resources and the aggregate alias', async () => {
     const search = request('GET', '/search?q=hello')
     trackRequest(search.req, search.res, 'browse', 'search')
@@ -191,10 +201,13 @@ describe('named server events', () => {
 
   test('request_failed maps catalog codes onto coarse error types', () => {
     expect(errorTypeFor('not_found', 404)).toBe('not_found')
+    expect(errorTypeFor('syndication_empty', 404)).toBe('not_found')
     expect(errorTypeFor('invalid_url', 400)).toBe('validation_error')
     expect(errorTypeFor('invalid_body', 400)).toBe('parse_error')
     expect(errorTypeFor('rate_limited', 429)).toBe('rate_limited')
     expect(errorTypeFor('fxtwitter_error', 502)).toBe('upstream_error')
+    expect(errorTypeFor('firecrawl_invalid', 502)).toBe('upstream_error')
+    expect(errorTypeFor('internal_error', 500)).toBe('upstream_error')
     expect(errorTypeFor(undefined, 500)).toBe('upstream_error')
   })
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -108,7 +108,10 @@ function truthy(value: string | undefined): boolean {
 function threadValue(raw: string | undefined): string {
   if (!raw) return 'full'
   if (raw === 'off' || raw === 'full' || raw === 'conversation') return raw
-  if (/^\d+$/.test(raw)) return raw
+  if (/^\d+$/.test(raw)) {
+    const n = Number.parseInt(raw, 10)
+    if (n >= 2 && n <= 100) return raw
+  }
   return 'full'
 }
 
@@ -149,17 +152,18 @@ function requesterBot(ua: string): string | null {
 
 export function errorTypeFor(code: string | undefined, status: number): string {
   if (code === 'rate_limited' || status === 429) return 'rate_limited'
-  if (code === 'not_found' || code === 'route_not_found' || code === 'private_tweet' || status === 404) return 'not_found'
-  if (code === 'invalid_body' || code?.endsWith('_invalid')) return 'parse_error'
+  if (status === 404 || code === 'not_found' || code === 'route_not_found' || code === 'private_tweet') return 'not_found'
+  if (code === 'invalid_body') return 'parse_error'
   if (
-    code === 'upstream_error'
+    status >= 500
+    || code === 'upstream_error'
     || code === 'search_unavailable'
     || code === 'all_providers_failed'
+    || code === 'internal_error'
     || code?.includes('fxtwitter')
     || code?.includes('syndication')
     || code?.includes('firecrawl')
     || code?.includes('contextdev')
-    || status >= 500
   ) return 'upstream_error'
   return 'validation_error'
 }
@@ -177,8 +181,9 @@ function safeMessage(value: string | undefined): string | undefined {
 }
 
 function distinctId(token: string, ctx: AnalyticsContext | undefined, keyStatus?: unknown): string {
-  if (keyStatus === 'valid' && ctx?.identity.keyId) {
-    return `key:${createHmac('sha256', token).update(ctx.identity.keyId).digest('hex')}`
+  const keyId = ctx?.identity.keyId
+  if (keyId && (keyStatus === 'valid' || keyStatus === undefined)) {
+    return `key:${createHmac('sha256', token).update(keyId).digest('hex')}`
   }
   return `anonymous:${ctx?.requestId ?? randomUUID()}`
 }
@@ -256,10 +261,10 @@ export function fallbackReasonFor(error: unknown): FallbackReason {
   return 'primary_error'
 }
 
-export function noteRequestError(res: object, code: string, message?: string): void {
+export function noteRequestError(res: object, code: string, message?: string, status?: number): void {
   const ctx = byResponse.get(res) ?? context.getStore()
   if (!ctx) return
-  ctx.error = { type: errorTypeFor(code, 0), message: safeMessage(message) }
+  ctx.error = { type: errorTypeFor(code, status ?? 0), message: safeMessage(message) }
 }
 
 export function captureCacheLookup(status: 'hit' | 'miss' | 'bypass', cacheKeyType: string): void {
@@ -392,8 +397,8 @@ function endpointProperties(req: IncomingMessage, endpoint: AnalyticsEndpoint): 
 }
 
 /**
- * One personless event per completed production function response. Explicit
- * fields only: never serialize the request, URL, headers, body, or errors.
+ * Production-only personless events for API traffic. Explicit fields only:
+ * never serialize the request, URL, headers, body, or provider payloads.
  * CDN hits don't invoke the function and are intentionally not counted.
  */
 export function trackRequest(

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,12 +1,394 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { createHmac, randomUUID } from 'node:crypto'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { waitUntil } from '@vercel/functions'
 
 type Endpoint = 'convert' | 'browse' | 'oembed' | 'mcp' | 'index' | 'notfound'
 
+export type AnalyticsEndpoint =
+  | 'status_convert'
+  | 'generic_convert'
+  | 'profile_browse'
+  | 'search_browse'
+  | 'followers_browse'
+  | 'following_browse'
+  | 'oembed'
+  | 'api_browse'
+
+export type CacheKeyType = 'status' | 'profile' | 'search' | 'followers' | 'following'
+export type RateLimitType = 'ip' | 'key' | 'global'
+export type UpstreamErrorType = 'timeout' | 'http_error' | 'parse_failure' | 'empty_response'
+export type FallbackReason = 'primary_timeout' | 'primary_error' | 'primary_empty'
+
 /** Only a verified, internal key ID may be assigned here. Never a bearer token. */
 interface RequestIdentity {
   keyId?: string
+}
+
+interface RequestErrorNote {
+  type: string
+  message?: string
+}
+
+interface AnalyticsContext {
+  identity: RequestIdentity
+  route: string
+  endpoint?: AnalyticsEndpoint
+  requestId: string
+  started: number
+  req: IncomingMessage
+  error?: RequestErrorNote
+}
+
+const EVENTS = new Set([
+  'request_completed',
+  'endpoint_called',
+  'request_failed',
+  'upstream_error',
+  'cache_hit',
+  'cache_miss',
+  'media_resolved',
+  'fallback_used',
+  'rate_limit_applied',
+  'batch_browse_called',
+  'search_executed',
+  'oEmbed_requested',
+])
+
+const CACHE_KEY_TYPES = new Set<string>(['status', 'profile', 'search', 'followers', 'following'])
+const FORMATS = new Set(['markdown', 'obsidian', 'json'])
+const REPLIES = new Set(['top', 'recent', 'off'])
+const FEEDS = new Set(['latest', 'top', 'photos', 'videos', 'users'])
+const BROWSE_RESOURCES = new Set(['profile', 'search', 'followers', 'following'])
+const OEMBED_FORMATS = new Set(['json', 'xml'])
+const ERROR_TYPES = new Set(['not_found', 'upstream_error', 'parse_error', 'rate_limited', 'validation_error'])
+const UPSTREAM_ERROR_TYPES = new Set<string>(['timeout', 'http_error', 'parse_failure', 'empty_response'])
+const FALLBACK_REASONS = new Set<string>(['primary_timeout', 'primary_error', 'primary_empty'])
+const RATE_LIMIT_TYPES = new Set<string>(['ip', 'key', 'global'])
+const MEDIA_TYPES = new Set(['video', 'image', 'mixed'])
+
+const context = new AsyncLocalStorage<AnalyticsContext>()
+const byResponse = new WeakMap<object, AnalyticsContext>()
+
+function config(): { token: string; host: string } | undefined {
+  const token = process.env.POSTHOG_PROJECT_TOKEN || process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
+  const host = process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST
+  if (process.env.VERCEL_ENV !== 'production' || !token || !host?.startsWith('https://')) return undefined
+  return { token, host: host.replace(/\/$/, '') }
+}
+
+function queryOf(req: IncomingMessage): URLSearchParams {
+  try {
+    return new URL(req.url ?? '/', 'https://x.pcstyle.dev').searchParams
+  } catch {
+    return new URLSearchParams()
+  }
+}
+
+function queryParam(req: IncomingMessage, key: string): string | undefined {
+  const fromUrl = queryOf(req).get(key)
+  if (fromUrl != null && fromUrl !== '') return fromUrl
+  const query = (req as IncomingMessage & { query?: Record<string, unknown> }).query
+  const value = query?.[key]
+  return typeof value === 'string' && value !== '' ? value : undefined
+}
+
+function requestPath(req: IncomingMessage): string {
+  try {
+    return new URL(req.url ?? '/', 'https://x.pcstyle.dev').pathname
+  } catch {
+    return ''
+  }
+}
+
+function truthy(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || value === 'yes'
+}
+
+function threadValue(raw: string | undefined): string {
+  if (!raw) return 'full'
+  if (raw === 'off' || raw === 'full' || raw === 'conversation') return raw
+  if (/^\d+$/.test(raw)) return raw
+  return 'full'
+}
+
+function classifyEndpoint(endpoint: Endpoint, resource: unknown, req: IncomingMessage): AnalyticsEndpoint | undefined {
+  if (endpoint === 'oembed') return 'oembed'
+  if (endpoint === 'convert') {
+    return queryParam(req, 'handle') && queryParam(req, 'id') ? 'status_convert' : 'generic_convert'
+  }
+  if (endpoint !== 'browse') return undefined
+  const via = queryParam(req, 'via')
+  if (requestPath(req) === '/api/browse' && via !== 'route') return 'api_browse'
+  const named = String(resource ?? queryParam(req, 'resource') ?? '')
+  if (named === 'profile') return 'profile_browse'
+  if (named === 'search') return 'search_browse'
+  if (named === 'followers') return 'followers_browse'
+  if (named === 'following') return 'following_browse'
+  return 'api_browse'
+}
+
+function trafficType(req: IncomingMessage | undefined): 'AI Agent' | 'Bot' | undefined {
+  const ua = String(req?.headers['user-agent'] ?? '')
+  if (!ua) return undefined
+  if (/gptbot|claudebot|chatgpt|anthropic|perplexity|google-extended|cohere-ai|amazonbot|bytespider|meta-externalagent|ccbot|ai2bot/i.test(ua)) {
+    return 'AI Agent'
+  }
+  if (/bot|crawler|spider|slackbot|slack-img|discordbot|telegrambot|facebookexternalhit|linkedinbot|whatsapp/i.test(ua)) {
+    return 'Bot'
+  }
+  return undefined
+}
+
+function requesterBot(ua: string): string | null {
+  if (/discordbot/i.test(ua)) return 'Discordbot'
+  if (/slackbot|slack-img/i.test(ua)) return 'Slackbot'
+  if (/telegrambot/i.test(ua)) return 'TelegramBot'
+  return null
+}
+
+export function errorTypeFor(code: string | undefined, status: number): string {
+  if (code === 'rate_limited' || status === 429) return 'rate_limited'
+  if (code === 'not_found' || code === 'route_not_found' || code === 'private_tweet' || status === 404) return 'not_found'
+  if (code === 'invalid_body' || code?.endsWith('_invalid')) return 'parse_error'
+  if (
+    code === 'upstream_error'
+    || code === 'search_unavailable'
+    || code === 'all_providers_failed'
+    || code?.includes('fxtwitter')
+    || code?.includes('syndication')
+    || code?.includes('firecrawl')
+    || code?.includes('contextdev')
+    || status >= 500
+  ) return 'upstream_error'
+  return 'validation_error'
+}
+
+function safeMessage(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const cleaned = value
+    .replace(/https?:\/\/\S+/gi, '')
+    .replace(/@\w+/g, '')
+    .replace(/[\u0000-\u001f\u007f-\u009f<>]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!cleaned) return undefined
+  return cleaned.length > 200 ? `${cleaned.slice(0, 199)}…` : cleaned
+}
+
+function distinctId(token: string, ctx: AnalyticsContext | undefined, keyStatus?: unknown): string {
+  if (keyStatus === 'valid' && ctx?.identity.keyId) {
+    return `key:${createHmac('sha256', token).update(ctx.identity.keyId).digest('hex')}`
+  }
+  return `anonymous:${ctx?.requestId ?? randomUUID()}`
+}
+
+function baseProperties(ctx: AnalyticsContext | undefined): Record<string, unknown> {
+  const traffic = trafficType(ctx?.req)
+  return {
+    environment: 'production',
+    $process_person_profile: false,
+    $geoip_disable: true,
+    $ip: null,
+    ...(traffic ? { $virt_traffic_type: traffic } : {}),
+  }
+}
+
+async function deliver(event: string, properties: Record<string, unknown>, id: string, token: string, host: string): Promise<void> {
+  try {
+    const uuid = randomUUID()
+    const response = await fetch(`${host}/i/v0/e/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(3000),
+      body: JSON.stringify({
+        api_key: token,
+        event,
+        uuid,
+        distinct_id: id,
+        timestamp: new Date().toISOString(),
+        properties,
+      }),
+    })
+    if (!response.ok) console.warn('[analytics] PostHog rejected an event')
+  } catch {
+    // Analytics must never change an API response or log request details.
+    console.warn('[analytics] PostHog event delivery failed')
+  }
+}
+
+function emit(
+  event: string,
+  properties: Record<string, unknown>,
+  ctx?: AnalyticsContext,
+  keyStatus?: unknown,
+): Promise<void> {
+  const cfg = config()
+  if (!cfg || !EVENTS.has(event)) return Promise.resolve()
+  const store = ctx ?? context.getStore()
+  return deliver(event, { ...baseProperties(store), ...properties }, distinctId(cfg.token, store, keyStatus), cfg.token, cfg.host)
+}
+
+function enqueue(event: string, properties: Record<string, unknown>, ctx?: AnalyticsContext, keyStatus?: unknown): void {
+  waitUntil(emit(event, properties, ctx, keyStatus))
+}
+
+/** Personless production capture. Explicit fields only; never serialize the request. */
+export function capture(event: string, properties: Record<string, unknown>): void {
+  enqueue(event, properties, context.getStore())
+}
+
+export function currentRoute(): string {
+  return context.getStore()?.route ?? 'unknown'
+}
+
+export function currentEndpoint(): AnalyticsEndpoint | 'unknown' {
+  return context.getStore()?.endpoint ?? 'unknown'
+}
+
+export function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')
+}
+
+export function fallbackReasonFor(error: unknown): FallbackReason {
+  if (isTimeoutError(error)) return 'primary_timeout'
+  if (error instanceof Error && /empty/i.test(error.message)) return 'primary_empty'
+  return 'primary_error'
+}
+
+export function noteRequestError(res: object, code: string, message?: string): void {
+  const ctx = byResponse.get(res) ?? context.getStore()
+  if (!ctx) return
+  ctx.error = { type: errorTypeFor(code, 0), message: safeMessage(message) }
+}
+
+export function captureCacheLookup(status: 'hit' | 'miss' | 'bypass', cacheKeyType: string): void {
+  if (status !== 'hit' && status !== 'miss') return
+  const type = CACHE_KEY_TYPES.has(cacheKeyType) ? cacheKeyType : 'unknown'
+  capture(status === 'hit' ? 'cache_hit' : 'cache_miss', {
+    route: currentRoute(),
+    endpoint: currentEndpoint(),
+    cache_key_type: type,
+  })
+}
+
+export function captureUpstreamError(input: {
+  provider: string
+  errorType: UpstreamErrorType
+  upstreamStatus?: number | null
+  durationMs: number
+  route?: string
+}): void {
+  const errorType = UPSTREAM_ERROR_TYPES.has(input.errorType) ? input.errorType : 'http_error'
+  capture('upstream_error', {
+    provider: input.provider,
+    route: input.route ?? currentRoute(),
+    error_type: errorType,
+    upstream_status: typeof input.upstreamStatus === 'number' ? input.upstreamStatus : null,
+    duration_ms: Math.max(0, Math.round(input.durationMs)),
+  })
+}
+
+export function captureFallback(input: {
+  primaryProvider: string
+  fallbackProvider: string
+  reason: FallbackReason
+  route?: string
+}): void {
+  capture('fallback_used', {
+    primary_provider: input.primaryProvider,
+    fallback_provider: input.fallbackProvider,
+    reason: FALLBACK_REASONS.has(input.reason) ? input.reason : 'primary_error',
+    route: input.route ?? currentRoute(),
+  })
+}
+
+export function captureRateLimit(limitType: RateLimitType, route?: string): void {
+  capture('rate_limit_applied', {
+    limit_type: RATE_LIMIT_TYPES.has(limitType) ? limitType : 'ip',
+    route: route ?? currentRoute(),
+  })
+}
+
+export function captureSearchExecuted(input: {
+  feedType: string
+  hasQuery: boolean
+  resultCount: number
+}): void {
+  const feed = FEEDS.has(input.feedType) ? input.feedType : 'latest'
+  capture('search_executed', {
+    feed_type: feed,
+    has_query: input.hasQuery,
+    result_count: Math.max(0, Math.round(input.resultCount)),
+  })
+}
+
+export function captureBatchBrowse(input: {
+  resource: string
+  format: string
+  resultCount: number
+  hasCursor: boolean
+}): void {
+  if (!BROWSE_RESOURCES.has(input.resource)) return
+  capture('batch_browse_called', {
+    resource: input.resource,
+    format: input.format === 'json' ? 'json' : 'markdown',
+    result_count: Math.max(0, Math.round(input.resultCount)),
+    has_cursor: input.hasCursor,
+  })
+}
+
+export function captureOEmbedRequested(userAgent: string, format?: string | null): void {
+  capture('oEmbed_requested', {
+    requester_bot: requesterBot(userAgent),
+    format: format && OEMBED_FORMATS.has(format) ? format : 'json',
+  })
+}
+
+interface MediaLike {
+  photos?: unknown[]
+  videos?: Array<{ url?: string; variants?: unknown[] }>
+  animated?: Array<{ url?: string; variants?: unknown[] }>
+  all?: Array<{ type?: string; url?: string; variants?: unknown[] }>
+}
+
+function mediaItems(media: MediaLike | undefined): Array<{ type?: string; url?: string; variants?: unknown[] }> {
+  if (!media) return []
+  if (media.all?.length) return media.all
+  return [
+    ...(media.photos ?? []).map(() => ({ type: 'photo' })),
+    ...(media.videos ?? []).map((item) => ({ type: 'video', ...item })),
+    ...(media.animated ?? []).map((item) => ({ type: 'animated_gif', ...item })),
+  ]
+}
+
+export function captureMediaResolved(posts: ReadonlyArray<{ media?: MediaLike; quote?: { media?: MediaLike } }>): void {
+  const items = posts.flatMap((post) => [...mediaItems(post.media), ...mediaItems(post.quote?.media)])
+  if (!items.length) return
+  const videos = items.filter((item) => item.type === 'video' || item.type === 'animated_gif' || item.type === 'animated')
+  const images = items.filter((item) => item.type === 'photo' || item.type === 'image')
+  const mediaType = videos.length && images.length ? 'mixed' : videos.length ? 'video' : 'image'
+  if (!MEDIA_TYPES.has(mediaType)) return
+  capture('media_resolved', {
+    media_type: mediaType,
+    variant_count: videos.reduce((sum, item) => sum + (item.variants?.length ?? 0), 0),
+    has_direct_url: videos.some((item) => Boolean(item.url) || Boolean(item.variants?.length)),
+    route: currentRoute(),
+  })
+}
+
+function endpointProperties(req: IncomingMessage, endpoint: AnalyticsEndpoint): Record<string, unknown> {
+  const format = queryParam(req, 'format')
+  const replies = queryParam(req, 'replies')
+  return {
+    endpoint,
+    format: format && FORMATS.has(format) ? format : 'markdown',
+    full: truthy(queryParam(req, 'full')),
+    thread: threadValue(queryParam(req, 'thread')),
+    replies: replies && REPLIES.has(replies) ? replies : 'top',
+    nocache: truthy(queryParam(req, 'nocache')),
+    has_handle: Boolean(queryParam(req, 'handle')),
+  }
 }
 
 /**
@@ -21,54 +403,54 @@ export function trackRequest(
   resource?: unknown,
 ): RequestIdentity {
   const identity: RequestIdentity = {}
-  const token = process.env.POSTHOG_PROJECT_TOKEN || process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN
-  const host = process.env.POSTHOG_HOST || process.env.NEXT_PUBLIC_POSTHOG_HOST
-  if (process.env.VERCEL_ENV !== 'production' || !token || !host?.startsWith('https://') || req.method === 'OPTIONS') return identity
+  const cfg = config()
+  if (!cfg || req.method === 'OPTIONS') return identity
 
   const started = performance.now()
   const route = endpoint === 'browse' && ['profile', 'search', 'followers', 'following'].includes(String(resource))
     ? String(resource) : endpoint
   const method = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method ?? '') ? req.method : 'OTHER'
+  const named = classifyEndpoint(endpoint, resource, req)
+  const ctx: AnalyticsContext = {
+    identity,
+    route,
+    endpoint: named,
+    requestId: randomUUID(),
+    started,
+    req,
+  }
+  byResponse.set(res, ctx)
+  context.enterWith(ctx)
+
+  if (named) enqueue('endpoint_called', endpointProperties(req, named), ctx)
 
   async function send() {
-    try {
-      const cacheHeader = res.getHeader('X-Cache')
-      const cache = cacheHeader === 'HIT' ? 'hit' : cacheHeader === 'MISS' ? 'miss' : cacheHeader === 'BYPASS' ? 'bypass' : 'unknown'
-      const keyStatus = res.getHeader('X-Api-Key-Status')
-      const auth = keyStatus === 'valid' || keyStatus === 'invalid' || keyStatus === 'unverified' ? keyStatus : 'anonymous'
-      const uuid = randomUUID()
-      const response = await fetch(`${host!.replace(/\/$/, '')}/i/v0/e/`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        signal: AbortSignal.timeout(3000),
-        body: JSON.stringify({
-          api_key: token,
-          event: 'request_completed',
-          uuid,
-          distinct_id: auth === 'valid' && identity.keyId
-            ? `key:${createHmac('sha256', token!).update(identity.keyId).digest('hex')}`
-            : `anonymous:${uuid}`,
-          timestamp: new Date().toISOString(),
-          properties: {
-            route,
-            method,
-            status: res.statusCode,
-            duration_ms: Math.max(0, Math.round(performance.now() - started)),
-            cache,
-            access: auth === 'valid' ? 'key' : 'public',
-            key_status: auth,
-            degraded: res.getHeader('X-Search-Degraded') === 'true',
-            environment: 'production',
-            $process_person_profile: false,
-            $geoip_disable: true,
-            $ip: null,
-          },
-        }),
-      })
-      if (!response.ok) console.warn('[analytics] PostHog rejected an event')
-    } catch {
-      // Analytics must never change an API response or log request details.
-      console.warn('[analytics] PostHog event delivery failed')
+    const cacheHeader = res.getHeader('X-Cache')
+    const cache = cacheHeader === 'HIT' ? 'hit' : cacheHeader === 'MISS' ? 'miss' : cacheHeader === 'BYPASS' ? 'bypass' : 'unknown'
+    const keyStatus = res.getHeader('X-Api-Key-Status')
+    const auth = keyStatus === 'valid' || keyStatus === 'invalid' || keyStatus === 'unverified' ? keyStatus : 'anonymous'
+    const status = res.statusCode
+    const duration = Math.max(0, Math.round(performance.now() - started))
+    await emit('request_completed', {
+      route,
+      method,
+      status,
+      duration_ms: duration,
+      cache,
+      access: auth === 'valid' ? 'key' : 'public',
+      key_status: auth,
+      degraded: res.getHeader('X-Search-Degraded') === 'true',
+    }, ctx, auth)
+    if (status >= 400) {
+      const noted = ctx.error
+      const errorType = noted?.type && ERROR_TYPES.has(noted.type) ? noted.type : errorTypeFor(undefined, status)
+      await emit('request_failed', {
+        route,
+        status,
+        error_type: errorType,
+        ...(noted?.message ? { error_message: noted.message } : {}),
+        duration_ms: duration,
+      }, ctx, auth)
     }
   }
 

--- a/lib/apierror.ts
+++ b/lib/apierror.ts
@@ -333,7 +333,7 @@ export function sendProblem(
   accept: string,
   method = 'GET',
 ): unknown {
-  noteRequestError(res, problem.code, problem.title)
+  noteRequestError(res, problem.code, problem.title, problem.status)
   const response = problemResponse(problem, accept)
   for (const [key, value] of Object.entries(response.headers)) {
     if (key === 'Link') appendLink(res, value)

--- a/lib/apierror.ts
+++ b/lib/apierror.ts
@@ -7,6 +7,7 @@
  * `error` field is kept as an alias so existing callers keep working.
  */
 
+import { noteRequestError } from './analytics.js'
 import { ConvertError } from './errors.js'
 import { mediaQuality } from './negotiate.js'
 
@@ -332,6 +333,7 @@ export function sendProblem(
   accept: string,
   method = 'GET',
 ): unknown {
+  noteRequestError(res, problem.code, problem.title)
   const response = problemResponse(problem, accept)
   for (const [key, value] of Object.entries(response.headers)) {
     if (key === 'Link') appendLink(res, value)

--- a/lib/archive-handlers.test.ts
+++ b/lib/archive-handlers.test.ts
@@ -43,7 +43,7 @@ test.each([convertHandler, browseHandler])('real handler emits separate complete
   const { req, res } = exchange(); await handler(req, res)
   const sent = await events()
   expect(res.statusCode).toBe(200)
-  expect(sent.map(event => event.event).sort()).toEqual(['request_completed', 'xmd_data_captured'])
+  expect(sent.map(event => event.event).sort()).toEqual(['endpoint_called', 'request_completed', 'xmd_data_captured'])
   expect(sent.find(event => event.event === 'request_completed').properties.payload).toBeUndefined()
   expect(sent.find(event => event.event === 'xmd_data_captured').properties.payload.posts).toEqual(posts)
   expect(JSON.stringify(sent)).not.toContain('private-')
@@ -52,19 +52,19 @@ test.each([convertHandler, browseHandler])('real handler emits separate complete
 
 test.each([convertHandler, browseHandler])('HEAD only emits metadata, errors never archive', async handler => {
   const { req, res } = exchange('HEAD'); await handler(req, res)
-  expect((await events()).map(event => event.event)).toEqual(['request_completed'])
+  expect((await events()).map(event => event.event).sort()).toEqual(['endpoint_called', 'request_completed'])
   vi.mocked(convertTweet).mockRejectedValue(new ConvertError(404, 'not found', 'not_found'))
   vi.mocked(browse).mockRejectedValue(new ConvertError(404, 'not found', 'not_found'))
   const failure = exchange(); await handler(failure.req, failure.res)
   expect(failure.res.statusCode).toBe(404)
-  expect((await events()).every(event => event.event === 'request_completed')).toBe(true)
+  expect((await events()).every(event => event.event === 'request_completed' || event.event === 'endpoint_called' || event.event === 'request_failed')).toBe(true)
 })
 
 test('invalid API key returns 401 without browsing or archive', async () => {
   vi.mocked(resolveCaller).mockResolvedValue({ caller: { kind: 'public' }, status: 'invalid', ip: '192.0.2.1' })
   const { req, res } = exchange(); await browseHandler(req, res)
   expect(res.statusCode).toBe(401); expect(browse).not.toHaveBeenCalled()
-  expect((await events()).map(event => event.event)).toEqual(['request_completed'])
+  expect((await events()).map(event => event.event).sort()).toEqual(['endpoint_called', 'request_completed', 'request_failed'])
 })
 
 test('verified key actor never enters public response or payload', async () => {

--- a/lib/browse.ts
+++ b/lib/browse.ts
@@ -1,4 +1,4 @@
-import { captureCacheLookup, captureFallback, captureRateLimit, captureSearchExecuted } from './analytics.js'
+import { captureCacheLookup, captureFallback, captureRateLimit, captureSearchExecuted, fallbackReasonFor } from './analytics.js'
 import {
   buildCacheKey,
   cacheControlHeader,
@@ -240,7 +240,7 @@ async function browseUncached(input: BrowseInput, resource: BrowseResource, page
           captureFallback({
             primaryProvider: 'fxtwitter',
             fallbackProvider: provider.source,
-            reason: 'primary_error',
+            reason: fallbackReasonFor(outage),
           })
         }
         return render({ resource, posts: list.results.slice(0, limit), query, feed, page, limit, nextCursor: tagCursor(provider.source, list.cursor?.bottom), source: provider.source })
@@ -257,7 +257,7 @@ async function browseUncached(input: BrowseInput, resource: BrowseResource, page
       captureFallback({
         primaryProvider: 'fxtwitter',
         fallbackProvider: 'firecrawl',
-        reason: 'primary_error',
+        reason: fallbackReasonFor(outage),
       })
       return render({ resource, posts, query, feed, page, limit, source: 'firecrawl', degraded: true })
     }

--- a/lib/browse.ts
+++ b/lib/browse.ts
@@ -1,3 +1,4 @@
+import { captureCacheLookup, captureFallback, captureRateLimit, captureSearchExecuted } from './analytics.js'
 import {
   buildCacheKey,
   cacheControlHeader,
@@ -192,20 +193,25 @@ async function browseUncached(input: BrowseInput, resource: BrowseResource, page
   const full = truthy(input.full)
   if (resource === 'search') {
     const query = input.q?.trim()
-    if (!query) throw new ConvertError(400, 'Search query q is required.', 'missing_query')
     const requestedFeed = input.feed?.toLowerCase() ?? 'latest'
     const feed = requestedFeed === 'media' ? 'photos' : ['latest', 'top', 'photos', 'videos', 'users'].includes(requestedFeed) ? requestedFeed : 'latest'
+    if (!query) {
+      captureSearchExecuted({ feedType: feed, hasQuery: false, resultCount: 0 })
+      throw new ConvertError(400, 'Search query q is required.', 'missing_query')
+    }
     // Front-door burst gate for every live search provider (FxTwitter, own accounts,
     // Firecrawl): anonymous callers per IP, key callers per key with a looser burst.
     const caller: SearchCaller = input.caller ?? { kind: 'public', ip: input.ip ?? undefined }
     if (caller.kind === 'key') {
       const verdict = await rateLimit(searchKeyKey(caller.id), SEARCH_KEY.quota, SEARCH_KEY.windowSec)
       if (!verdict.allowed) {
+        captureRateLimit('key')
         throw new ConvertError(429, 'Too many live search lookups for this API key in a short burst. Slow down and retry shortly.', 'rate_limited', verdict.retryAfter, SEARCH_KEY.name)
       }
     } else if (caller.ip) {
       const verdict = await rateLimit(searchIpKey(caller.ip), SEARCH_IP.quota, SEARCH_IP.windowSec)
       if (!verdict.allowed) {
+        captureRateLimit('ip')
         throw new ConvertError(429, 'Too many live search lookups from this IP. Slow down and retry shortly.', 'rate_limited', verdict.retryAfter, SEARCH_IP.name)
       }
     }
@@ -230,6 +236,13 @@ async function browseUncached(input: BrowseInput, resource: BrowseResource, page
     for (const provider of providers) {
       try {
         const list = await walkPages(page, tagged?.raw, provider.search)
+        if (!tagged && ['latest', 'top'].includes(feed) && provider.source !== 'fxtwitter') {
+          captureFallback({
+            primaryProvider: 'fxtwitter',
+            fallbackProvider: provider.source,
+            reason: 'primary_error',
+          })
+        }
         return render({ resource, posts: list.results.slice(0, limit), query, feed, page, limit, nextCursor: tagCursor(provider.source, list.cursor?.bottom), source: provider.source })
       } catch (error) {
         if (!(error instanceof ConvertError && error.code === 'search_unavailable')) throw error
@@ -241,6 +254,11 @@ async function browseUncached(input: BrowseInput, resource: BrowseResource, page
     // Web-index fallback only for a fresh first page: it has no notion of X cursors.
     if (['latest', 'top'].includes(feed) && page === 1 && !tagged && firecrawlSearchConfigured()) {
       const posts = await searchFirecrawlStatuses(query, feed, limit)
+      captureFallback({
+        primaryProvider: 'fxtwitter',
+        fallbackProvider: 'firecrawl',
+        reason: 'primary_error',
+      })
       return render({ resource, posts, query, feed, page, limit, source: 'firecrawl', degraded: true })
     }
     throw outage ?? new ConvertError(503, 'X search is temporarily unavailable upstream. Retry shortly.', 'search_unavailable')
@@ -283,6 +301,14 @@ export async function browse(input: BrowseInput): Promise<BrowseResult> {
     () => browseUncached(input, resource, page, limit),
     (value) => (value.degraded ? DEGRADED_TTL_MS : undefined),
   )
+  captureCacheLookup(cached.status, resource)
+  if (resource === 'search') {
+    captureSearchExecuted({
+      feedType: cached.value.feed ?? 'latest',
+      hasQuery: Boolean(input.q?.trim()),
+      resultCount: cached.value.posts?.length ?? cached.value.users?.length ?? 0,
+    })
+  }
   return { ...cached.value, cache: cached.status }
 }
 

--- a/lib/contextdev.ts
+++ b/lib/contextdev.ts
@@ -1,3 +1,4 @@
+import { captureUpstreamError, isTimeoutError } from './analytics.js'
 import { ConvertError } from './errors.js'
 import type { FxTweet } from './fxtwitter.js'
 import { extractStatusTextFromMarkdown } from './scrape-text.js'
@@ -25,6 +26,7 @@ export async function fetchContextDevStatus(handle: string, id: string): Promise
   url.searchParams.set('includeLinks', 'true')
   url.searchParams.set('includeImages', 'false')
 
+  const started = performance.now()
   let response: Response
   try {
     response = await fetch(url, {
@@ -34,7 +36,13 @@ export async function fetchContextDevStatus(handle: string, id: string): Promise
         'User-Agent': UA,
       },
     })
-  } catch {
+  } catch (error) {
+    captureUpstreamError({
+      provider: 'contextdev',
+      errorType: isTimeoutError(error) ? 'timeout' : 'http_error',
+      upstreamStatus: null,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(502, 'Failed to reach Context.dev API.', 'contextdev_network')
   }
 
@@ -42,10 +50,22 @@ export async function fetchContextDevStatus(handle: string, id: string): Promise
   try {
     payload = (await response.json()) as ContextDevMarkdownResponse
   } catch {
+    captureUpstreamError({
+      provider: 'contextdev',
+      errorType: 'parse_failure',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(502, 'Context.dev returned an invalid response.', 'contextdev_invalid')
   }
 
   if (!response.ok || payload.success === false) {
+    captureUpstreamError({
+      provider: 'contextdev',
+      errorType: 'http_error',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(
       502,
       payload.error ?? payload.message ?? `Context.dev returned ${response.status}.`,
@@ -55,6 +75,12 @@ export async function fetchContextDevStatus(handle: string, id: string): Promise
 
   const markdown = payload.markdown?.trim()
   if (!markdown) {
+    captureUpstreamError({
+      provider: 'contextdev',
+      errorType: 'empty_response',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(502, 'Context.dev returned empty content.', 'contextdev_empty')
   }
 

--- a/lib/converter.ts
+++ b/lib/converter.ts
@@ -1,3 +1,4 @@
+import { captureCacheLookup, captureMediaResolved } from './analytics.js'
 import {
   buildCacheKey,
   cacheControlHeader,
@@ -268,6 +269,8 @@ export async function convertTweet(input: ConvertInput): Promise<ConvertSuccess>
   const { value, status } = await withCache(cacheKey, nocache, async () =>
     convertTweetUncached(format, thread, userinfo, canonicalUrl, handle, id, compact, context, replies),
   )
+  captureCacheLookup(status, 'status')
+  captureMediaResolved(value.posts)
 
   return { ...value, cache: status }
 }

--- a/lib/firecrawl.ts
+++ b/lib/firecrawl.ts
@@ -1,3 +1,4 @@
+import { captureUpstreamError, isTimeoutError } from './analytics.js'
 import { ConvertError } from './errors.js'
 import type { FxTweet } from './fxtwitter.js'
 import { extractStatusTextFromMarkdown } from './scrape-text.js'
@@ -69,6 +70,7 @@ export async function searchFirecrawlStatuses(queryText: string, feed: string, l
     throw new ConvertError(503, 'Firecrawl search fallback not configured.', 'firecrawl_disabled')
   }
 
+  const started = performance.now()
   let response: Response
   try {
     response = await fetch(FIRECRAWL_SEARCH_API, {
@@ -85,7 +87,13 @@ export async function searchFirecrawlStatuses(queryText: string, feed: string, l
       }),
       signal: AbortSignal.timeout(15_000),
     })
-  } catch {
+  } catch (error) {
+    captureUpstreamError({
+      provider: 'firecrawl',
+      errorType: isTimeoutError(error) ? 'timeout' : 'http_error',
+      upstreamStatus: null,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(503, 'Failed to reach Firecrawl search.', 'firecrawl_network')
   }
 
@@ -93,9 +101,21 @@ export async function searchFirecrawlStatuses(queryText: string, feed: string, l
   try {
     payload = (await response.json()) as FirecrawlSearchResponse
   } catch {
+    captureUpstreamError({
+      provider: 'firecrawl',
+      errorType: 'parse_failure',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(503, 'Firecrawl search returned an invalid response.', 'firecrawl_invalid')
   }
   if (!response.ok || payload.success === false) {
+    captureUpstreamError({
+      provider: 'firecrawl',
+      errorType: 'http_error',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(503, payload.error ?? `Firecrawl search returned ${response.status}.`, 'firecrawl_error')
   }
 
@@ -126,6 +146,7 @@ export async function fetchFirecrawlStatus(handle: string, id: string): Promise<
 
   const canonicalUrl = `https://x.com/${handle}/status/${id}`
 
+  const started = performance.now()
   let response: Response
   try {
     response = await fetch(FIRECRAWL_API, {
@@ -142,13 +163,36 @@ export async function fetchFirecrawlStatus(handle: string, id: string): Promise<
         waitFor: 2000,
       }),
     })
-  } catch {
+  } catch (error) {
+    captureUpstreamError({
+      provider: 'firecrawl',
+      errorType: isTimeoutError(error) ? 'timeout' : 'http_error',
+      upstreamStatus: null,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(502, 'Failed to reach Firecrawl API.', 'firecrawl_network')
   }
 
-  const payload = (await response.json()) as FirecrawlResponse
+  let payload: FirecrawlResponse
+  try {
+    payload = (await response.json()) as FirecrawlResponse
+  } catch {
+    captureUpstreamError({
+      provider: 'firecrawl',
+      errorType: 'parse_failure',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
+    throw new ConvertError(502, 'Firecrawl returned an invalid response.', 'firecrawl_invalid')
+  }
 
   if (!response.ok || !payload.success) {
+    captureUpstreamError({
+      provider: 'firecrawl',
+      errorType: 'http_error',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(
       502,
       payload.error ?? `Firecrawl returned ${response.status}.`,
@@ -158,6 +202,12 @@ export async function fetchFirecrawlStatus(handle: string, id: string): Promise<
 
   const markdown = payload.data?.markdown?.trim()
   if (!markdown) {
+    captureUpstreamError({
+      provider: 'firecrawl',
+      errorType: 'empty_response',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(502, 'Firecrawl returned empty content.', 'firecrawl_empty')
   }
 

--- a/lib/fxtwitter.ts
+++ b/lib/fxtwitter.ts
@@ -1,3 +1,4 @@
+import { captureUpstreamError, isTimeoutError } from './analytics.js'
 import { ConvertError } from './errors.js'
 
 const FX_BASE = 'https://api.fxtwitter.com'
@@ -207,16 +208,34 @@ function pickTweet(data: FxApiResponse): FxTweet | undefined {
 }
 
 async function fxFetchJson<T>(path: string): Promise<T> {
+  const started = performance.now()
   let response: Response
   try {
     response = await fetch(`${FX_BASE}/${path}`, {
       headers: { Accept: 'application/json', 'User-Agent': UA },
     })
-  } catch {
+  } catch (error) {
+    captureUpstreamError({
+      provider: 'fxtwitter',
+      errorType: isTimeoutError(error) ? 'timeout' : 'http_error',
+      upstreamStatus: null,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(502, 'Failed to reach FxTwitter API.', 'fxtwitter_network')
   }
 
-  const data = (await response.json()) as FxApiResponse
+  let data: FxApiResponse
+  try {
+    data = (await response.json()) as FxApiResponse
+  } catch {
+    captureUpstreamError({
+      provider: 'fxtwitter',
+      errorType: 'parse_failure',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
+    throw new ConvertError(502, 'Failed to reach FxTwitter API.', 'fxtwitter_network')
+  }
 
   if (data.code === 404 || data.message === 'NOT_FOUND') {
     throw new ConvertError(404, 'Post not found or unavailable.', 'not_found')
@@ -227,6 +246,12 @@ async function fxFetchJson<T>(path: string): Promise<T> {
   }
 
   if (!response.ok || (data.code && data.code >= 400)) {
+    captureUpstreamError({
+      provider: 'fxtwitter',
+      errorType: 'http_error',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(
       502,
       `FxTwitter API error: ${data.message ?? response.status}.`,
@@ -282,6 +307,7 @@ export async function searchFxStatuses(
     // timeline at all (upstream account/session failure, see FxEmbed#2303). That is
     // an outage, not a missing post, so surface it as retryable.
     if (error instanceof ConvertError && error.code === 'not_found') {
+      captureUpstreamError({ provider: 'fxtwitter', errorType: 'empty_response', upstreamStatus: 404, durationMs: 0 })
       throw new ConvertError(503, 'X search is temporarily unavailable upstream. Retry shortly.', 'search_unavailable')
     }
     throw error

--- a/lib/fxtwitter.ts
+++ b/lib/fxtwitter.ts
@@ -234,7 +234,7 @@ async function fxFetchJson<T>(path: string): Promise<T> {
       upstreamStatus: response.status,
       durationMs: performance.now() - started,
     })
-    throw new ConvertError(502, 'Failed to reach FxTwitter API.', 'fxtwitter_network')
+    throw new ConvertError(502, 'FxTwitter API returned an invalid response.', 'fxtwitter_invalid')
   }
 
   if (data.code === 404 || data.message === 'NOT_FOUND') {

--- a/lib/ratelimit-headers.ts
+++ b/lib/ratelimit-headers.ts
@@ -16,6 +16,7 @@
  * `rateLimit()` call against the shared counter. A stale or absent header can
  * mislead a client's self-pacing, never x.md's own throttling.
  */
+import { captureRateLimit } from './analytics.js'
 import type { HeaderWriter } from './http.js'
 import {
   ACCOUNT_IP,
@@ -185,6 +186,7 @@ export async function chargeRequestQuota(scope: QuotaScope, caller: QuotaCaller)
     states.push({ ...policy, remaining: Math.max(0, policy.quota - used), resetSec: windowClock(policy.windowSec).remainingSec })
   }
 
+  if (!verdict.allowed) captureRateLimit('ip')
   return { allowed: verdict.allowed, retryAfter: verdict.retryAfter, states, degraded: verdict.degraded || counts === undefined }
 }
 

--- a/lib/syndication.ts
+++ b/lib/syndication.ts
@@ -1,3 +1,4 @@
+import { captureUpstreamError, isTimeoutError } from './analytics.js'
 import { ConvertError } from './errors.js'
 import type { FxArticle, FxArticleBlock, FxMedia, FxMediaItem, FxTweet } from './fxtwitter.js'
 
@@ -155,15 +156,30 @@ function mapSyndicationTweet(raw: SyndicationTweet, handle?: string, id?: string
 }
 
 export async function fetchSyndicationStatus(handle: string, id: string): Promise<FxTweet> {
+  const started = performance.now()
   let response: Response
   try {
     const url = `${SYNDICATION_BASE}?id=${encodeURIComponent(id)}&lang=en&token=0`
     response = await fetch(url, { headers: { 'User-Agent': UA, Accept: 'application/json' } })
-  } catch {
+  } catch (error) {
+    captureUpstreamError({
+      provider: 'syndication',
+      errorType: isTimeoutError(error) ? 'timeout' : 'http_error',
+      upstreamStatus: null,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(502, 'Failed to reach X syndication API.', 'syndication_network')
   }
 
   if (!response.ok) {
+    if (response.status !== 404) {
+      captureUpstreamError({
+        provider: 'syndication',
+        errorType: 'http_error',
+        upstreamStatus: response.status,
+        durationMs: performance.now() - started,
+      })
+    }
     throw new ConvertError(
       response.status === 404 ? 404 : 502,
       'Post not found via syndication API.',
@@ -171,8 +187,25 @@ export async function fetchSyndicationStatus(handle: string, id: string): Promis
     )
   }
 
-  const data = (await response.json()) as SyndicationTweet
+  let data: SyndicationTweet
+  try {
+    data = (await response.json()) as SyndicationTweet
+  } catch {
+    captureUpstreamError({
+      provider: 'syndication',
+      errorType: 'parse_failure',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
+    throw new ConvertError(502, 'Post not found via syndication API.', 'syndication_error')
+  }
   if (!data?.text && !data?.article) {
+    captureUpstreamError({
+      provider: 'syndication',
+      errorType: 'empty_response',
+      upstreamStatus: response.status,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(404, 'Post not found via syndication API.', 'syndication_empty')
   }
 

--- a/lib/syndication.ts
+++ b/lib/syndication.ts
@@ -197,7 +197,7 @@ export async function fetchSyndicationStatus(handle: string, id: string): Promis
       upstreamStatus: response.status,
       durationMs: performance.now() - started,
     })
-    throw new ConvertError(502, 'Post not found via syndication API.', 'syndication_error')
+    throw new ConvertError(502, 'Syndication API returned an invalid response.', 'syndication_invalid')
   }
   if (!data?.text && !data?.article) {
     captureUpstreamError({

--- a/lib/tweet-fetch.ts
+++ b/lib/tweet-fetch.ts
@@ -1,3 +1,4 @@
+import { captureFallback, fallbackReasonFor } from './analytics.js'
 import { ConvertError } from './errors.js'
 import { fetchContextDevStatus } from './contextdev.js'
 import { fetchFirecrawlStatus } from './firecrawl.js'
@@ -76,10 +77,19 @@ async function fetchStatusWithFallback(handle: string, id: string): Promise<Fetc
   }
 
   let lastError: unknown
+  const primary = 'fxtwitter'
 
-  for (const attempt of attempts) {
+  for (const [index, attempt] of attempts.entries()) {
     try {
-      return await attempt()
+      const result = await attempt()
+      if (index > 0) {
+        captureFallback({
+          primaryProvider: primary,
+          fallbackProvider: result.source,
+          reason: fallbackReasonFor(lastError),
+        })
+      }
+      return result
     } catch (error) {
       lastError = error
       if (isHardNotFound(error)) throw error

--- a/lib/xsearch.ts
+++ b/lib/xsearch.ts
@@ -17,6 +17,7 @@ import {
   type Tweet,
   type Profile,
 } from '@the-convocation/twitter-scraper'
+import { captureRateLimit, captureUpstreamError } from './analytics.js'
 import { ConvertError } from './errors.js'
 import type { FxAuthor, FxListResponse, FxTweet } from './fxtwitter.js'
 import { poolSnapshot, resetPool, type PoolSnapshot } from './pool.js'
@@ -269,11 +270,18 @@ export function searchRateModel(): {
 }
 
 async function withSearchSession<T>(search: (scraper: Scraper) => Promise<T>, caller?: SearchCaller): Promise<T> {
+  const started = performance.now()
   const now = Date.now()
   const candidates = sessionStates()
     .filter((state) => !state.disabled && state.coolUntil <= now)
     .sort((a, b) => a.coolUntil - b.coolUntil)
   if (candidates.length === 0) {
+    captureUpstreamError({
+      provider: 'xsearch',
+      errorType: 'empty_response',
+      upstreamStatus: null,
+      durationMs: performance.now() - started,
+    })
     throw new ConvertError(503, 'X search is temporarily unavailable upstream. Retry shortly.', 'search_unavailable')
   }
 
@@ -284,6 +292,7 @@ async function withSearchSession<T>(search: (scraper: Scraper) => Promise<T>, ca
     const ipKey = accountIpKey(caller.ip ?? '')
     const fair = await rateLimit(ipKey, ACCOUNT_IP.quota, ACCOUNT_IP.windowSec, true)
     if (!fair.allowed) {
+      captureRateLimit('ip')
       throw new ConvertError(429, 'Account-backed search allowance reached for this IP. Retry after the current window.', 'rate_limited', fair.retryAfter, ACCOUNT_IP.name)
     }
     // Shared public cap: whatever the pool has left after key usage and reservations.
@@ -291,6 +300,7 @@ async function withSearchSession<T>(search: (scraper: Scraper) => Promise<T>, ca
     const shared = await rateLimit(ACCOUNT_PUBLIC_COUNTER, await publicCapNow(), ACCOUNT_WINDOW_SEC, true, true)
     if (!shared.allowed) {
       await refundRateLimit(ipKey, ACCOUNT_WINDOW_SEC, fair.bucket)
+      captureRateLimit('global')
       // Reported against the caller's own per-IP policy: the shared pool's level is fleet health, not a personal quota.
       throw new ConvertError(429, 'Public search capacity is used up for this window. Retry after it resets.', 'rate_limited', shared.retryAfter, ACCOUNT_IP.name)
     }
@@ -298,6 +308,7 @@ async function withSearchSession<T>(search: (scraper: Scraper) => Promise<T>, ca
     // Refund rejected attempts: they must not count as pool usage in the snapshot.
     const fair = await rateLimit(accountKeyKey(caller.id), caller.limit, ACCOUNT_WINDOW_SEC, true, true)
     if (!fair.allowed) {
+      captureRateLimit('key')
       throw new ConvertError(429, 'API key search allowance reached. Retry after the current window.', 'rate_limited', fair.retryAfter, ACCOUNT_KEY_NAME)
     }
   }
@@ -319,5 +330,11 @@ async function withSearchSession<T>(search: (scraper: Scraper) => Promise<T>, ca
       console.warn(`[xsearch] session ${state.session.id} ${last.kind}: ${last.detail}`)
     }
   }
+  captureUpstreamError({
+    provider: 'xsearch',
+    errorType: last?.detail?.toLowerCase().includes('timeout') ? 'timeout' : 'http_error',
+    upstreamStatus: last?.kind === 'rate_limit' ? 429 : null,
+    durationMs: performance.now() - started,
+  })
   throw new ConvertError(503, 'X search is temporarily unavailable upstream. Retry shortly.', 'search_unavailable')
 }


### PR DESCRIPTION
`request_completed` only fires after a production function finishes, so volume, 4xx/5xx, cache lookups, provider fallbacks, and our own rate limits were invisible as their own events.

this captures those at the existing call sites. production only, personless, structural properties. no query text, post ids, handles, or upstream bodies.

**events:** `endpoint_called`, `request_failed`, `upstream_error`, `cache_hit`/`cache_miss`, `media_resolved`, `fallback_used`, `rate_limit_applied`, `batch_browse_called`, `search_executed`, `oEmbed_requested`

**validation**
- `bun run test`: 546 passed
- `bun run build`: tsc + docs + vite succeeded