### PR TITLE
fix: article metadata in social previews and snapshot freshness

### DIFF
--- a/lib/converter.test.ts
+++ b/lib/converter.test.ts
@@ -257,10 +257,10 @@ describe('canonicalThreadCacheValue — cache key normalisation', () => {
     )
   })
 
-  test('cache key uses version 5, normalized handle, and includes post-context defaults', async () => {
+  test('cache key uses version 6, normalized handle, and includes post-context defaults', async () => {
     await convertTweet({ url: validUrl, thread: 'full' })
     expect(mockedBuildCacheKey).toHaveBeenCalledWith(
-      expect.objectContaining({ v: 5, handle: 'testuser', context: 'full', replies: 'top' }),
+      expect.objectContaining({ v: 6, handle: 'testuser', context: 'full', replies: 'top' }),
     )
   })
 
@@ -291,4 +291,14 @@ describe('canonicalThreadCacheValue — cache key normalisation', () => {
     expect(keyFromNull).toEqual(keyFromFull)
     expect(keyFromFull).toEqual(keyFromConversation)
   })
+})
+
+
+test('JSON exposes snapshot time and bypass responses cannot be cached by clients or CDN', async () => {
+  const result = await convertTweet({ url: 'https://x.com/testuser/status/1234567890', format: 'json' })
+  expect(Number.isFinite(Date.parse(result.fetchedAt!))).toBe(true)
+  const response = markdownResponse({ ...result, cache: 'bypass' }, true)
+  expect(JSON.parse(response.body).fetched_at).toBe(result.fetchedAt)
+  expect(response.headers['Cache-Control']).toBe('no-store')
+  expect(response.headers['Vercel-CDN-Cache-Control']).toBe('no-store')
 })

--- a/lib/converter.ts
+++ b/lib/converter.ts
@@ -36,6 +36,8 @@ export interface ConvertSuccess {
   cache: CacheStatus
   posts: FxTweet[]
   compact: boolean
+  /** When this service retrieved the upstream snapshot, not the upstream's own cache age. */
+  fetchedAt?: string
 }
 
 import type { FxTweet } from './fxtwitter.js'
@@ -235,6 +237,7 @@ async function convertTweetUncached(
 
   return {
     body,
+    fetchedAt: new Date().toISOString(),
     warnings,
     canonicalUrl,
     format,
@@ -256,7 +259,7 @@ export async function convertTweet(input: ConvertInput): Promise<ConvertSuccess>
   const { canonicalUrl, handle, id } = resolveTarget(input)
 
   const cacheKey = buildCacheKey({
-    v: 5,
+    v: 6,
     id,
     handle: handle.toLowerCase(),
     format,
@@ -320,6 +323,9 @@ export function markdownResponse(result: ConvertSuccess, asJson = false, asHtml 
   if (result.cache !== 'bypass') {
     sharedHeaders['Cache-Control'] = cacheControlHeader()
     sharedHeaders['Vercel-CDN-Cache-Control'] = vercelCacheControlHeader()
+  } else {
+    sharedHeaders['Cache-Control'] = 'no-store'
+    sharedHeaders['Vercel-CDN-Cache-Control'] = 'no-store'
   }
 
   if (asJson) {
@@ -336,6 +342,7 @@ export function markdownResponse(result: ConvertSuccess, asJson = false, asHtml 
         postCount: result.postCount,
         source: result.source,
         cache: result.cache,
+        fetched_at: result.fetchedAt,
       }),
     }
   }

--- a/lib/embed.test.ts
+++ b/lib/embed.test.ts
@@ -275,6 +275,19 @@ describe('embed and oEmbed responses', () => {
     expect(response.body).toContain('Nathan (@nthglsn)')
   })
 
+  test('bypassed not-found previews cannot be cached', () => {
+    const response = embedResponse({ ...result, posts: [], cache: 'bypass' }, { origin: 'https://mdfromx.com' })
+    expect(response.status).toBe(404)
+    expect(response.headers['Cache-Control']).toBe('no-store')
+    expect(response.headers['Vercel-CDN-Cache-Control']).toBe('no-store')
+  })
+
+  test('bypassed HTML previews cannot be cached', () => {
+    const response = embedResponse({ ...result, cache: 'bypass' }, { origin: 'https://mdfromx.com', userAgent: 'Discordbot/2.0' })
+    expect(response.headers['Cache-Control']).toBe('no-store')
+    expect(response.headers['Vercel-CDN-Cache-Control']).toBe('no-store')
+  })
+
   test('oembedPayload maps query fields the way Discord reads them', () => {
     expect(
       oembedPayload(
@@ -321,5 +334,24 @@ describe('embed and oEmbed responses', () => {
       provider_url: 'https://x.com/hams/status/2089772419175047410',
       type: 'rich',
     })
+  })
+})
+
+describe('article previews', () => {
+  const article: FxTweet = {
+    id: '2098047492772249730', text: 'https://x.com/i/article/2098045587400658947',
+    author: { name: 'Mustafa Ali', screen_name: 'mustafa01ali', avatar_url: 'https://pbs.twimg.com/avatar.jpg' },
+    article: { title: 'Shopify is moving from React Native to Native', preview_text: 'Moving our mobile apps back to Swift and Kotlin.', cover_media: { media_info: { original_img_url: 'https://pbs.twimg.com/article.jpg' } } },
+  }
+  test('uses article title, excerpt and cover instead of a naked URL and avatar', () => {
+    const html = buildEmbedHtml(article, { origin: 'https://mdfromx.com', userAgent: 'Discordbot/2.0' })
+    expect(html).toContain('og:title" content="Shopify is moving from React Native to Native')
+    expect(html).toContain('Moving our mobile apps back to Swift and Kotlin.')
+    expect(html).toContain('og:image" content="https://pbs.twimg.com/article.jpg')
+    expect(html).toContain('summary_large_image')
+    expect(html).toContain('Mustafa Ali')
+  })
+  test('falls back to article blocks when the preview is missing', () => {
+    expect(embedDescription({ ...article, article: { title: 'Title', content: { blocks: [{ text: 'First paragraph.' }] } } })).toContain('First paragraph.')
   })
 })

--- a/lib/embed.ts
+++ b/lib/embed.ts
@@ -84,7 +84,12 @@ function pollBlock(poll: FxPoll, barLength = 32): string {
 }
 
 export function embedDescription(tweet: FxTweet): string {
-  let text = tweet.text ?? ''
+  let text = tweet.article?.preview_text?.trim() ||
+    tweet.article?.content?.blocks?.map(block => block.text?.trim()).filter(Boolean).join('\n\n').slice(0, 1000) || tweet.text || ''
+  if (tweet.article?.title) {
+    const author = tweet.author?.name ?? tweet.author?.screen_name
+    if (author) text = `${author}${tweet.author?.screen_name ? ` (@${tweet.author.screen_name})` : ''}\n\n${text}`
+  }
   if (tweet.poll && Array.isArray(tweet.poll.choices)) {
     text += pollBlock(tweet.poll)
   }
@@ -205,6 +210,8 @@ function stillImagePlan(item: FxMediaItem | undefined): MediaPlan | undefined {
 }
 
 function mediaPlan(tweet: FxTweet, multiImage: boolean, staticVideoFallback: boolean): MediaPlan {
+  const cover = tweet.article?.cover_media?.media_info?.original_img_url
+  if (cover) return { card: 'summary_large_image', tags: photoTags({ url: cover }) }
   const own = tweet.media
   const quoted = tweet.quote?.media
   const video = firstVideo(own) ?? firstVideo(quoted)
@@ -273,7 +280,7 @@ export function buildEmbedHtml(tweet: FxTweet, options: EmbedOptions): string {
   const name = tweet.author?.name ?? handle
   const id = tweet.id ?? '0'
   const canonical = tweet.url ?? `https://x.com/${handle}/status/${id}`
-  const title = `${name} (@${handle})`
+  const title = tweet.article?.title?.trim() || `${name} (@${handle})`
   const description = embedDescription(tweet)
   const proof = socialProof(tweet) ?? 'Embed'
   const userAgent = options.userAgent ?? ''
@@ -321,7 +328,7 @@ export function embedResponse(
   if (!tweet) {
     return {
       status: 404,
-      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      headers: { 'Content-Type': 'application/json; charset=utf-8', ...(result.cache === 'bypass' ? { 'Cache-Control': 'no-store', 'Vercel-CDN-Cache-Control': 'no-store' } : {}) },
       body: JSON.stringify({ error: 'Post not found or unavailable.', code: 'not_found' }),
     }
   }
@@ -341,6 +348,9 @@ export function embedResponse(
     const ttl = Number.parseInt(process.env.CACHE_TTL_SECONDS ?? '3600', 10)
     const seconds = Number.isFinite(ttl) && ttl > 0 ? ttl : 3600
     headers['Vercel-CDN-Cache-Control'] = `public, s-maxage=${seconds}, stale-while-revalidate=86400`
+  } else {
+    headers['Cache-Control'] = 'no-store'
+    headers['Vercel-CDN-Cache-Control'] = 'no-store'
   }
 
   return { status: 200, headers, body: buildEmbedHtml(tweet, options) }

--- a/lib/openapi.ts
+++ b/lib/openapi.ts
@@ -1208,6 +1208,7 @@ function schemas(): Record<string, JsonSchema> {
         compact: { type: 'boolean', description: 'False when `full=true` widened the rendering.' },
         warnings: { type: 'array', description: 'Non-fatal notes, such as a truncated thread or a fallback provider. Always present, often empty.', items: { type: 'string' } },
         postCount: int('Length of `posts`.'),
+        fetched_at: { type: 'string', format: 'date-time', description: 'When x.md fetched this upstream snapshot. Preserved on cache hits; upstream providers may have their own cache.' },
         source: { type: 'string', enum: ['fxtwitter', 'syndication', 'contextdev', 'firecrawl'], description: 'Upstream provider that answered.' },
         cache: { type: 'string', enum: ['hit', 'miss', 'bypass'], description: 'Whether the application cache served this response.' },
       },

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -9944,6 +9944,11 @@
             "type": "integer",
             "description": "Length of `posts`."
           },
+          "fetched_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When x.md fetched this upstream snapshot. Preserved on cache hits; upstream providers may have their own cache."
+          },
           "source": {
             "type": "string",
             "enum": [


### PR DESCRIPTION
Article links currently render as a bare URL and author avatar in Discord because the social renderer ignores article metadata. Use the article title, preview text (or body excerpt), and cover image while retaining attribution and existing tweet/media fallbacks.

The JSON response also exposes when the upstream snapshot was fetched. Explicit cache-bypass responses use no-store headers, allowing clients such as newscord to refresh statistics without reusing the service’s cached snapshot. This timestamp does not claim that upstream providers have no cache.

Validation: 689 tests, the production build, and OpenAPI consistency checks pass. Regression tests reproduce the article failure in the attached screenshot and verify title, excerpt, cover, and partial-metadata fallback.

![Before: article preview missing cover and excerpt](https://github.com/user-attachments/assets/6c23d430-fd74-4bcc-9b59-ac9c2325d669)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Article previews now display titles, preview text, cover images, and enhanced social cards.
  - Article descriptions fall back to available article content when preview text is unavailable.
  - Conversion responses include an optional `fetched_at` timestamp indicating when the upstream snapshot was retrieved.
  - Bypassed-cache responses are explicitly marked as non-cacheable.

- **Documentation**
  - Updated API documentation to describe the `fetched_at` response field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


rebased onto b48a94a after the x-md-fast merge; the expanded 689-test suite and production build pass.
