### PR TITLE
fix: accept long pagination cursors in MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Notable changes to x.md. Versions are git tags on `main`; the hosted API at x.pcstyle.dev always runs the latest tagged release.
 
+## 1.1.1 - 2026-09-11
+
+- fixed mcp pagination rejecting continuation cursors longer than 1,024 characters. clients can now pass long `next_cursor` values back unchanged.
+
 ## 1.1.0 - 2026-09-08
 
 An agent-readiness release. Nothing in 1.0.0 changed behaviour; everything below is additive, and the routes that got a new name kept their old one.

--- a/lib/mcp.test.ts
+++ b/lib/mcp.test.ts
@@ -171,6 +171,29 @@ describe('tools/call', () => {
     expect(Object.keys(structured).filter((key) => !allowed.includes(key))).toEqual([])
   })
 
+  test('search accepts its own long continuation cursor on the next call', async () => {
+    // Live conversation searches produce growing cursors: page four of the
+    // reported conversation returned 1,290 characters, beyond the old cap.
+    const cursor = `xsearch:${'a'.repeat(1282)}`
+    const args = { q: 'conversation_id:2097725468569207019' }
+    const page = {
+      resource: 'search' as const, query: args.q, feed: 'latest',
+      page: 1, limit: 20, source: 'xsearch' as const, cache: 'miss' as const,
+      posts: [{ id: '1', text: 'first reply' }], markdown: '# first page',
+    }
+    browseMock.mockResolvedValueOnce({ ...page, nextCursor: cursor })
+    const first = ok(await dispatch({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'x_md_search_posts', arguments: args } }))
+    const nextCursor = (first.structuredContent as Record<string, unknown>).next_cursor
+    expect(nextCursor).toBe(cursor)
+
+    browseMock.mockResolvedValueOnce({ ...page, posts: [{ id: '2', text: 'next reply' }], markdown: '# next page' })
+    const next = ok(await dispatch({ jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'x_md_search_posts', arguments: { ...args, cursor: nextCursor } } }))
+    expect(next.isError).toBe(false)
+    expect(browseMock).toHaveBeenLastCalledWith(expect.objectContaining({ resource: 'search', q: args.q, cursor }))
+    expect(next.structuredContent).toMatchObject({ posts: [{ id: '2' }] })
+    expect(next.structuredContent).not.toHaveProperty('next_cursor')
+  })
+
   test('a post call maps max_posts onto the thread cap the converter takes', async () => {
     convertMock.mockResolvedValue({
       body: '# post',

--- a/lib/mcp.ts
+++ b/lib/mcp.ts
@@ -5,7 +5,7 @@ import type { SearchCaller } from './xsearch.js'
 
 export const MCP_SERVER_NAME = 'io.github.pc-style/x-md'
 export const MCP_SERVER_TITLE = 'x.md'
-export const MCP_SERVER_VERSION = '1.0.0'
+export const MCP_SERVER_VERSION = '1.1.1'
 export const MCP_SITE = 'https://x.pcstyle.dev'
 export const MCP_ENDPOINT = `${MCP_SITE}/mcp`
 export const MCP_DOCS_URL = `${MCP_SITE}/docs/mcp`
@@ -140,7 +140,6 @@ const PAGING_PROPERTIES = {
   },
   cursor: {
     type: 'string',
-    maxLength: 1024,
     description: 'Opaque continuation token returned as next_cursor by a previous call. Prefer it over page for deep pagination.',
   },
   full: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-md",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Agent-friendly, read-only X browser with compact Markdown and JSON output",
   "license": "MIT",
   "type": "module",

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -3,7 +3,7 @@
   "name": "io.github.pc-style/x-md",
   "title": "x.md",
   "description": "Read public X posts, threads, profiles, and search results as Markdown or JSON.",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "websiteUrl": "https://x.pcstyle.dev/",
   "documentationUrl": "https://x.pcstyle.dev/docs/mcp",
   "icons": [

--- a/public/server.json
+++ b/public/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.pc-style/x-md",
   "title": "x.md",
   "description": "Read public X posts, threads, profiles, and search results as Markdown or JSON.",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "websiteUrl": "https://x.pcstyle.dev/",
   "icons": [
     {


### PR DESCRIPTION
## what changed

mcp rejected continuation cursors longer than 1,024 characters, including cursors returned by its own search tool. removed that restriction so clients can pass `next_cursor` back unchanged. includes the `1.1.1` package and mcp version bump, discovery manifests, and release note for self-hosters.

## why

reproduced on `conversation_id:2097725468569207019`: page four returned a 1,290-character cursor. mcp rejected it with `-32602` (`cursor` must be at most 1024 characters); the same cursor worked through rest and returned 20 more replies.

## how to verify

- [x] regression test reproduced the rejection before the fix and passes after it
- [x] `bun run test`: 690 tests passed after rebasing onto main
- [x] `bun run build`: passed
- [x] preview replay at `3d680c2`: the same 1,290-character cursor returned 20 replies through mcp, with `isError: false` and a 1,391-character continuation
- docs already describe opaque cursors without a length ceiling; this brings mcp into line with that contract


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long pagination continuation cursors are now accepted and preserved, allowing clients to request subsequent result pages without truncation or validation errors.
  - `next_cursor` is omitted when no additional results are available.

- **Release**
  - Updated the server and package version to 1.1.1.

- **Documentation**
  - Added changelog details for the pagination fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->